### PR TITLE
Inverse solver enhancements

### DIFF
--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -346,7 +346,11 @@ class Equilibrium:
             )
             raise e
 
-        return fpol / R
+        # this is a temporary patch for singular input cases
+        if type(R) != np.ndarray and type(Z) != np.ndarray:
+            return fpol[0,0] / R
+        else:
+            return fpol / R
 
     def psi(self):
         """

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -348,7 +348,7 @@ class Equilibrium:
 
         # this is a temporary patch for singular input cases
         if type(R) != np.ndarray and type(Z) != np.ndarray:
-            return fpol[0,0] / R
+            return fpol[0, 0] / R
         else:
             return fpol / R
 


### PR DESCRIPTION
I've made some small improvements/enhancements to control.py (in the constrain class):

1. Removed the use of `np.linalg.inv` (which is typically unstable) and replaced with `np.linalg.solve`.
2. Added newer functionality from FreeGS that allows one to include constraints on the lower/upper coil currents allowed in each coil and the maximum total current in all the coils. 
3. An example of how these newer constraints can be used will be included in the FreeGSNKE example1 Jupyter notebook (in an upcoming pull request).
 
The minor modification in `equilbirium.py` is for obtaining singular output in `Btor()` function.