### PR TITLE
Equilibrium improvements

### DIFF
--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -77,7 +77,7 @@ class Equilibrium:
             The boundary condition function. Can be either `freeBoundary`
             or `fixedBoundary`.
         psi : np.array
-            Initial guess for plasma flux. If `None`, default initial guess used.
+            Initial guess for plasma flux [Webers/2pi]. If `None`, default initial guess used.
         current : float
             Plasma current [A].
         order : int
@@ -267,7 +267,7 @@ class Equilibrium:
 
         solver(x, b)
 
-        where x is the initial guess and b is the right hand side (thisshould solve Ax = b, 
+        where x is the initial guess and b is the right hand side (this should solve Ax = b, 
         returning the result).
         
                 
@@ -294,7 +294,7 @@ class Equilibrium:
         Parameters
         ----------
         psi : np.array
-            The initial guess. 
+            The initial guess [Webers/2pi]. 
         rhs : np.array
             The right hand side of the GS equation.
 
@@ -391,7 +391,7 @@ class Equilibrium:
         Returns
         -------
         float or np.array
-            The radial magnetic field due to the plasma at the given (R, Z) positions.
+            The radial magnetic field due to the plasma at the given (R, Z) positions [T].
         """
 
         return -self.psi_func(R, Z, dy=1, grid=False) / R
@@ -417,7 +417,7 @@ class Equilibrium:
         Returns
         -------
         float or np.array
-            The vertical magnetic field due to the plasma at the given (R, Z) positions.
+            The vertical magnetic field due to the plasma at the given (R, Z) positions [T].
         """
 
         return self.psi_func(R, Z, dx=1, grid=False) / R
@@ -443,7 +443,7 @@ class Equilibrium:
         Returns
         -------
         float or np.array
-            The total radial magnetic field at the given (R, Z) positions.
+            The total radial magnetic field at the given (R, Z) positions [T].
         """
         
         return self.plasmaBr(R, Z) + self.tokamak.Br(R, Z)
@@ -469,7 +469,7 @@ class Equilibrium:
         Returns
         -------
         float or np.array
-            The total vertical magnetic field at the given (R, Z) positions.
+            The total vertical magnetic field at the given (R, Z) positions [T].
         """
         
         return self.plasmaBz(R, Z) + self.tokamak.Bz(R, Z)
@@ -499,7 +499,7 @@ class Equilibrium:
         Returns
         -------
         float or np.array
-            The toroidal magnetic field at the given (R, Z) positions.
+            The toroidal magnetic field at the given (R, Z) positions [T].
         """
 
         # find f = R * Btor in the core
@@ -551,7 +551,7 @@ class Equilibrium:
         Returns
         -------
         float or np.array
-            The poloidal magnetic field at the given (R, Z) positions.
+            The poloidal magnetic field at the given (R, Z) positions [T].
         """
         
         Br = self.Br(R, Z)
@@ -577,7 +577,7 @@ class Equilibrium:
         Returns
         -------
         np.array
-            The total poloidal flux due to the plasma and the coils.          
+            The total poloidal flux due to the plasma and the coils [Webers/2pi].          
         """
 
         return self.plasma_psi + self.tokamak.calcPsiFromGreens(self._pgreen)
@@ -605,7 +605,7 @@ class Equilibrium:
         Returns
         -------
         float or np.array
-            The total poloidal flux due to the plasma and the coils at chosen (R,Z) locations. 
+            The total poloidal flux due to the plasma and the coils at chosen (R,Z) locations [Webers/2pi]. 
         """
         
         return self.psi_func(R, Z, grid=False) + self.tokamak.psi(R, Z)
@@ -655,7 +655,7 @@ class Equilibrium:
         -------
         np.array
             The total poloidal flux due to the plasma and the coils between the magnetic axis
-            and last closed flux surface.
+            and last closed flux surface [Webers/2pi].
         """
 
         return  np.linspace(self.psi_axis, self.psi_bndry, N)
@@ -757,7 +757,7 @@ class Equilibrium:
         Returns
         -------
         np.array
-            fpol at values of normalised psi.
+            fpol at values of normalised psi [Tm].
         """
         
         return self._profiles.fpol(psinorm)
@@ -772,7 +772,7 @@ class Equilibrium:
         Returns
         -------
         float
-            fvac value in vacuum. 
+            fvac value in vacuum [Tm]. 
         """
         
         return self._profiles.fvac()
@@ -824,7 +824,7 @@ class Equilibrium:
         Returns
         -------
         np.array
-            pprime (dp/dψ_n) at normalised flux values. 
+            pprime (dp/dψ_n) at normalised flux values [Pa/(Webers/2pi)]. 
         """
 
         return self._profiles.pprime(psinorm)
@@ -843,7 +843,7 @@ class Equilibrium:
         Returns
         -------
         np.array
-            ffprime (F * dF/dψ_n) at normalised flux values. 
+            ffprime (F * dF/dψ_n) at normalised flux values [T^2 m^2/(Wb/2pi)]. 
         """
         
         return self._profiles.ffprime(psinorm)
@@ -862,7 +862,7 @@ class Equilibrium:
         Returns
         -------
         np.array
-            pressure (p(ψ_n)) at normalised flux values. 
+            pressure (p(ψ_n)) at normalised flux values [Pa]. 
         """
         
         return self._profiles.pressure(psinorm)
@@ -898,7 +898,7 @@ class Equilibrium:
         Returns
         -------
         float
-            Area of the last closed flux surface (plasma boundary). 
+            Area of the last closed flux surface (plasma boundary) [m^2]. 
         """
 
         Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
@@ -915,7 +915,7 @@ class Equilibrium:
         Returns
         -------
         float
-            Circumference of the last closed flux surface (plasma boundary). 
+            Circumference of the last closed flux surface (plasma boundary) [m]. 
         """
 
         Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
@@ -975,7 +975,7 @@ class Equilibrium:
     
     def getForces(self):
         """
-        Calculates the forces on the coils.3
+        Calculates the forces on the coils.
         
         Parameters
         ----------
@@ -983,7 +983,7 @@ class Equilibrium:
         Returns
         -------
         dict
-            Coil lables with the associated force.  
+            Coil lables with the associated force [N].  
         """
         
         return self.tokamak.getForces(self)
@@ -1036,9 +1036,9 @@ class Equilibrium:
         Returns
         -------
         float
-            The inner separatrix major radius (at chosen Z).
+            The inner separatrix major radius (at chosen Z) [m].
         float
-            The outer separatrix major radius (at chosen Z).
+            The outer separatrix major radius (at chosen Z) [m].
         """
         
         # Find the closest index to requested Z
@@ -1106,7 +1106,7 @@ class Equilibrium:
         Returns
         -------
         list
-            List with the two (R,Z) coordinates: (R_in, Z) and (R_out, Z). 
+            List with the two (R,Z) coordinates: (R_in, Z) and (R_out, Z) [m]. 
         """
         
         # use shapely to define polygon of core plasma
@@ -1163,7 +1163,7 @@ class Equilibrium:
         Returns
         -------
         list 
-            Returns [R, Z, ψ(R, Z)] at magnetic axis location.       
+            Returns [R, Z, ψ(R, Z)] at magnetic axis location  [m, m, Webers/2pi].       
         """
         
         opt, xpt = critical.find_critical(self.R, self.Z, self.psi())
@@ -1509,7 +1509,7 @@ class Equilibrium:
         Returns
         -------
         list
-            Contains coordinates array and minimum distance to wall: [ (R,Z), min_distance ].
+            Contains coordinates array and minimum distance to wall: [ (R,Z), min_distance ] [m,m,m].
         """
 
         # create shapely linestring objects
@@ -1840,7 +1840,7 @@ class Equilibrium:
         Returns
         -------
         np.array
-            Returns an array of the (R,Z) strikepoints.
+            Returns an array of the (R,Z) strikepoints [m].
             
         """
 
@@ -1888,109 +1888,97 @@ class Equilibrium:
 
         return out
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-    def solve(self, profiles, Jtor=None, psi=None, psi_bndry=None):
+    def solve(self, 
+              profiles, 
+              Jtor=None, 
+              psi=None, 
+              psi_bndry=None
+              ):
         """
-        Calculate the plasma equilibrium given new profiles
-        replacing the current equilibrium.
-
-        This performs the linear Grad-Shafranov solve
-
-        profiles  - An object describing the plasma profiles.
-                    At minimum this must have methods:
-             .Jtor(R, Z, psi)   -> [nx, ny]
-             .pprime(psinorm)
-             .ffprime(psinorm)
-             .pressure(psinorm)
-             .fpol(psinorm)
-
-        Jtor : 2D array
-            If supplied, specifies the toroidal current at each (R,Z) point
-            If not supplied, Jtor is calculated from profiles by finding O,X-points
-
-        psi_bndry  - Poloidal flux to use as the separatrix (plasma boundary)
-                     If not given then X-point locations are used.
+        This is a legacy function that can be used to solve for the plasma equilibrium. It 
+        performs a linear Grad-Shafranov solve. 
+        
+        Parameters
+        ----------
+        profiles: class
+            Class containing the toroidal current density profile information.
+        Jtor: np.array
+            Toroidal current density field over (R,Z) [A/m^2].  
+        psi: np.array
+            Total poloidal magnetic flux over (R,Z) [Webers/2pi]. 
+        psi_bndry: float
+            Total poloidal magnetic flux on the plasma boundary [Webers/2pi]. 
+             
+        Returns
+        -------
+        None
+            Modifies the equilbirium class object in place.
+                        
         """
-
+        
+        # set profiles
         self._profiles = profiles
 
+        # calculate toroidal current density if not given (with psi)
         if Jtor is None:
-            # Calculate toroidal current density
-
             if psi is None:
                 psi = self.psi()
             Jtor = profiles.Jtor(self.R, self.Z, psi, psi_bndry=psi_bndry)
 
-        # Set plasma boundary
-        # Note that the Equilibrium is passed to the boundary function
-        # since the boundary may need to run the G-S solver (von Hagenow's method)
+        # set plasma boundary
+        # note that the Equilibrium is passed to the boundary function
+        # since the boundary may need to run the GS solver (von Hagenow's method)
         self._applyBoundary(self, Jtor, self.plasma_psi)
 
-        # Right hand side of G-S equation
+        # right hand side of GS equation
         rhs = -mu0 * self.R * Jtor
 
-        # Copy boundary conditions
+        # copy boundary conditions
         rhs[0, :] = self.plasma_psi[0, :]
         rhs[:, 0] = self.plasma_psi[:, 0]
         rhs[-1, :] = self.plasma_psi[-1, :]
         rhs[:, -1] = self.plasma_psi[:, -1]
 
-        # Call elliptic solver
+        # call elliptic solver
         plasma_psi = self._solver(self.plasma_psi, rhs)
 
         self._updatePlasmaPsi(plasma_psi)
 
-        # Update plasma current
-        dR = self.R[1, 0] - self.R[0, 0]
-        dZ = self.Z[0, 1] - self.Z[0, 0]
-        self._current = romb(romb(Jtor)) * dR * dZ
+        # update plasma current
+        self._current = romb(romb(Jtor)) * self.dR * self.dZ
 
-    def _updatePlasmaPsi(self, plasma_psi):
+    def _updatePlasmaPsi(self, 
+                         plasma_psi
+                         ):
         """
-        Sets the plasma psi data, updates spline interpolation coefficients.
-        Also updates:
-
-        self.mask        2D (R,Z) array which is 1 in the core, 0 outside
-        self.psi_axis    Value of psi on the magnetic axis
-        self.psi_bndry   Value of psi on plasma boundary
+        Sets the plasma psi data using spline interpoation coefficients. 
+        
+        Parameters
+        ----------
+        plasma_psi: np.array
+            Plasma poloidal magnetic flux over (R,Z) [Webers/2pi].
+             
+        Returns
+        -------
+        None
+            Modifies plasma_psi, mask, psi_axis, and psi_bndry in the class 
+            object in place.
+                        
         """
+        
+        # set plasma psi
         self.plasma_psi = plasma_psi
 
-        # Update spline interpolation
+        # update spline interpolation
         self.psi_func = interpolate.RectBivariateSpline(
             self.R[:, 0], self.Z[0, :], plasma_psi
         )
 
-        # Update the locations of the X-points, core mask, psi ranges.
+        # update locations of X-points, core mask, psi ranges.
         # Note that this may fail if there are no X-points, so it should not raise an error
         # Analyse the equilibrium, finding O- and X-points
         psi = self.psi()
         opt, xpt = critical.find_critical(self.R, self.Z, psi)
-        # if opt:
         self.psi_axis = opt[0][2]
 
         if len(xpt) > 0:
@@ -2011,155 +1999,43 @@ class Equilibrium:
             self.psi_bndry = None
             self.mask = None
 
-    def plot(self, axis=None, show=True, oxpoints=True):
+    def plot(self, 
+             axis=None, 
+             show=True, 
+             oxpoints=True
+             ):
         """
-        Plot the equilibrium flux surfaces
-
-        axis     - Specify the axis on which to plot
-        show     - Call matplotlib.pyplot.show() before returning
-        oxpoints - Plot X points as red circles, O points as green circles
-
+        Plot the equilibrium.
+        
+        Parameters
+        ----------
+        axis: object
+            Matplotlib axis object.  
+        show: bool
+            Calls matplotlib.pyplot.show() before returning.
+        oxpoints: bool
+            Plot X points and O points.
+             
         Returns
         -------
-
-        axis  object from Matplotlib
-
+        axis
+            Matplotlib axis object.
+                        
         """
+
         from .plotting import plotEquilibrium
 
         return plotEquilibrium(self, axis=axis, show=show, oxpoints=oxpoints)
 
-def refine(eq, nx=None, ny=None):
+def ellipse_points(
+    R0, 
+    Z0, 
+    A, 
+    B, 
+    N=360
+    ):
     """
-    Double grid resolution, returning a new equilibrium
-
-
-    """
-    # Interpolate the plasma psi
-    # plasma_psi = multigrid.interpolate(eq.plasma_psi)
-    # nx, ny = plasma_psi.shape
-
-    # By default double the number of intervals
-    if not nx:
-        nx = 2 * (eq.R.shape[0] - 1) + 1
-    if not ny:
-        ny = 2 * (eq.R.shape[1] - 1) + 1
-
-    result = Equilibrium(
-        tokamak=eq.tokamak,
-        Rmin=eq.Rmin,
-        Rmax=eq.Rmax,
-        Zmin=eq.Zmin,
-        Zmax=eq.Zmax,
-        boundary=eq._applyBoundary,
-        order=eq.order,
-        nx=nx,
-        ny=ny,
-    )
-
-    plasma_psi = eq.psi_func(result.R, result.Z, grid=False)
-
-    result._updatePlasmaPsi(plasma_psi)
-
-    if hasattr(eq, "_profiles"):
-        result._profiles = eq._profiles
-
-    if hasattr(eq, "control"):
-        result.control = eq.control
-
-    return result
-
-
-def coarsen(eq):
-    """
-    Reduce grid resolution, returning a new equilibrium
-    """
-    plasma_psi = multigrid.restrict(eq.plasma_psi)
-    nx, ny = plasma_psi.shape
-
-    result = Equilibrium(
-        tokamak=eq.tokamak,
-        Rmin=eq.Rmin,
-        Rmax=eq.Rmax,
-        Zmin=eq.Zmin,
-        Zmax=eq.Zmax,
-        nx=nx,
-        ny=ny,
-    )
-
-    result._updatePlasmaPsi(plasma_psi)
-
-    if hasattr(eq, "_profiles"):
-        result._profiles = eq._profiles
-
-    if hasattr(eq, "control"):
-        result.control = eq.control
-
-    return result
-
-
-def newDomain(
-    eq, Rmin=None, Rmax=None, Zmin=None, Zmax=None, nx=None, ny=None
-):
-    """Creates a new Equilibrium, solving in a different domain.
-    The domain size (Rmin, Rmax, Zmin, Zmax) and resolution (nx,ny)
-    are taken from the input equilibrium eq if not specified.
-    """
-    if Rmin is None:
-        Rmin = eq.Rmin
-    if Rmax is None:
-        Rmax = eq.Rmax
-    if Zmin is None:
-        Zmin = eq.Zmin
-    if Zmax is None:
-        Zmax = eq.Zmax
-    if nx is None:
-        nx = eq.R.shape[0]
-    if ny is None:
-        ny = eq.R.shape[0]
-
-    # Create a new equilibrium with the new domain
-    result = Equilibrium(
-        tokamak=eq.tokamak,
-        Rmin=Rmin,
-        Rmax=Rmax,
-        Zmin=Zmin,
-        Zmax=Zmax,
-        nx=nx,
-        ny=ny,
-    )
-
-    # Calculate the current on the old grid
-    profiles = eq._profiles
-    Jtor = profiles.Jtor(eq.R, eq.Z, eq.psi())
-
-    # Interpolate Jtor onto new grid
-    Jtor_func = interpolate.RectBivariateSpline(eq.R[:, 0], eq.Z[0, :], Jtor)
-    Jtor_new = Jtor_func(result.R, result.Z, grid=False)
-
-    result._applyBoundary(result, Jtor_new, result.plasma_psi)
-
-    # Right hand side of G-S equation
-    rhs = -mu0 * result.R * Jtor_new
-
-    # Copy boundary conditions
-    rhs[0, :] = result.plasma_psi[0, :]
-    rhs[:, 0] = result.plasma_psi[:, 0]
-    rhs[-1, :] = result.plasma_psi[-1, :]
-    rhs[:, -1] = result.plasma_psi[:, -1]
-
-    # Call elliptic solver
-    plasma_psi = result._solver(result.plasma_psi, rhs)
-
-    result._updatePlasmaPsi(plasma_psi)
-
-    # Solve once more, calculating Jtor using new psi
-    result.solve(profiles)
-
-    return result
-
-def ellipse_points(R0, Z0, A, B, N=360):
-    """This function generates the (R,Z) points of an ellipse:
+    This function generates the (R,Z) points of an ellipse:
     (x/A)**2 + (y/B)**2 = 1.
 
     Parameters
@@ -2181,6 +2057,192 @@ def ellipse_points(R0, Z0, A, B, N=360):
 
     return np.column_stack((R, Z))
 
+# def refine(eq, 
+#            nx=None, 
+#            ny=None
+#            ):
+#     """
+#     Function for changing the resolution of the equilibrium. 
+    
+#     Parameters
+#     ----------
+#     eq: class
+#         Equilibrium class object.   
+#     nx : int
+#         New number of radial grid points (must be of form 2^n + 1, n=0,1,2,3,4,5,...).
+#     ny : int
+#         New number of vertical grid points (must be of form 2^n + 1, n=0,1,2,3,4,5,...).
+            
+#     Returns
+#     -------
+#     class
+#         Returns a new equilibrium object with the new results.
+        
+#     """
+
+#     # by default double the number of intervals
+#     if not nx:
+#         nx = 2 * (eq.R.shape[0] - 1) + 1
+#     if not ny:
+#         ny = 2 * (eq.R.shape[1] - 1) + 1
+
+#     # define the new eq object
+#     result = Equilibrium(
+#         tokamak=eq.tokamak,
+#         Rmin=eq.Rmin,
+#         Rmax=eq.Rmax,
+#         Zmin=eq.Zmin,
+#         Zmax=eq.Zmax,
+#         boundary=eq._applyBoundary,
+#         order=eq.order,
+#         nx=nx,
+#         ny=ny,
+#     )
+
+#     # update the plasma psi from old eq
+#     plasma_psi = eq.psi_func(result.R, result.Z, grid=False)
+#     result._updatePlasmaPsi(plasma_psi)
+
+#     # copies profiles and constrain objects if needed
+#     if hasattr(eq, "_profiles"):
+#         result._profiles = eq._profiles
+
+#     if hasattr(eq, "control"):
+#         result.control = eq.control
+
+#     return result
+
+
+# def coarsen(eq):
+#     """
+#     Reduce grid resolution, returning a new equilibrium.
+    
+#     Parameters
+#     ----------
+#     eq: class
+#         Equilibrium class object.
+            
+#     Returns
+#     -------
+#     class
+#         Returns a new equilibrium object with the new results.
+        
+#     """
+
+#     plasma_psi = multigrid.restrict(eq.plasma_psi)
+#     nx, ny = plasma_psi.shape
+
+#     result = Equilibrium(
+#         tokamak=eq.tokamak,
+#         Rmin=eq.Rmin,
+#         Rmax=eq.Rmax,
+#         Zmin=eq.Zmin,
+#         Zmax=eq.Zmax,
+#         nx=nx,
+#         ny=ny,
+#     )
+
+#     result._updatePlasmaPsi(plasma_psi)
+
+#     if hasattr(eq, "_profiles"):
+#         result._profiles = eq._profiles
+
+#     if hasattr(eq, "control"):
+#         result.control = eq.control
+
+#     return result
+
+
+# def newDomain(
+#     eq, 
+#     Rmin=None, 
+#     Rmax=None, 
+#     Zmin=None, 
+#     Zmax=None, 
+#     nx=None, 
+#     ny=None
+#     ):
+#     """
+#     Creates a new equilibrium object, solving in a different domain.
+#     The domain size (Rmin, Rmax, Zmin, Zmax) and resolution (nx,ny)
+#     are taken from the input equilibrium eq if not specified.
+    
+#     Parameters
+#     ----------
+#     eq: class
+#         Equilibrium class object.
+#     Rmin : float
+#         Minimum major radius [m].
+#     Rmax : float
+#         Maximum major radius [m].
+#     Zmin : float
+#         Minimum height [m].
+#     Zmax : float
+#         Maximum height [m].
+#     nx : int
+#         Number of radial grid points (must be of form 2^n + 1, n=0,1,2,3,4,5,...).
+#     ny : int
+#         Number of vertical grid points (must be of form 2^n + 1, n=0,1,2,3,4,5,...).
+            
+#     Returns
+#     -------
+#     class
+#         Returns a new equilibrium object with the new results.
+        
+#     """
+
+#     if Rmin is None:
+#         Rmin = eq.Rmin
+#     if Rmax is None:
+#         Rmax = eq.Rmax
+#     if Zmin is None:
+#         Zmin = eq.Zmin
+#     if Zmax is None:
+#         Zmax = eq.Zmax
+#     if nx is None:
+#         nx = eq.R.shape[0]
+#     if ny is None:
+#         ny = eq.R.shape[0]
+
+#     # Create a new equilibrium with the new domain
+#     result = Equilibrium(
+#         tokamak=eq.tokamak,
+#         Rmin=Rmin,
+#         Rmax=Rmax,
+#         Zmin=Zmin,
+#         Zmax=Zmax,
+#         nx=nx,
+#         ny=ny,
+#     )
+
+#     # Calculate the current on the old grid
+#     profiles = eq._profiles
+#     Jtor = profiles.Jtor(eq.R, eq.Z, eq.psi())
+
+#     # Interpolate Jtor onto new grid
+#     Jtor_func = interpolate.RectBivariateSpline(eq.R[:, 0], eq.Z[0, :], Jtor)
+#     Jtor_new = Jtor_func(result.R, result.Z, grid=False)
+
+#     result._applyBoundary(result, Jtor_new, result.plasma_psi)
+
+#     # Right hand side of G-S equation
+#     rhs = -mu0 * result.R * Jtor_new
+
+#     # Copy boundary conditions
+#     rhs[0, :] = result.plasma_psi[0, :]
+#     rhs[:, 0] = result.plasma_psi[:, 0]
+#     rhs[-1, :] = result.plasma_psi[-1, :]
+#     rhs[:, -1] = result.plasma_psi[:, -1]
+
+#     # Call elliptic solver
+#     plasma_psi = result._solver(result.plasma_psi, rhs)
+
+#     result._updatePlasmaPsi(plasma_psi)
+
+#     # Solve once more, calculating Jtor using new psi
+#     result.solve(profiles)
+
+#     return result
 
 if __name__ == "__main__":
 

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -1,6 +1,6 @@
 """
-Defines class to represent the equilibrium
-state, including plasma and coil currents
+Defines class that represents the equilibrium state and its associated
+quantities.
 
 Modified substantially from the original FreeGS code.
 
@@ -21,47 +21,23 @@ along with FreeGS4E.  If not, see <http://www.gnu.org/licenses/>.
 """
 
 import warnings
-
 import matplotlib.pyplot as plt
 import numpy as np
 import shapely as sh
 from numpy import array, exp, linspace, meshgrid, pi
 from scipy import interpolate
-from scipy.integrate import romb  # Romberg integration
+from scipy.integrate import cumulative_trapezoid, romb
 
-# Multigrid solver
-from . import critical, machine, multigrid, polygons
-from .boundary import fixedBoundary, freeBoundary
 
-# Operators which define the G-S equation
-from .gradshafranov import GSsparse, GSsparse4thOrder, mu0
+from . import critical, machine, multigrid, polygons # multigrid solver
+from .boundary import fixedBoundary, freeBoundary  # finds free-boundary
+from .gradshafranov import GSsparse, GSsparse4thOrder, mu0 # operators which define the G-S equation
 
 
 class Equilibrium:
     """
-    Represents the equilibrium state, including
-    plasma and coil currents
+    Represents the plasma equilibrium state and its associated properties. 
 
-    Data members
-    ------------
-
-    These can be read, but should not be modified directly
-
-    R[nx,ny]
-    Z[nx,ny]
-
-    Rmin, Rmax
-    Zmin, Zmax
-
-    tokamak - The coils and circuits
-
-    Private data members
-
-    _applyBoundary()
-    _solver - Grad-Shafranov elliptic solver
-    _profiles     An object which calculates the toroidal current
-    _constraints  Control system which adjusts coil currents to meet constraints
-                  e.g. X-point location and flux values
     """
 
     def __init__(
@@ -78,53 +54,78 @@ class Equilibrium:
         current=0.0,
         order=4,
     ):
-        """Initialises a plasma equilibrium
-
-        Rmin, Rmax  - Range of major radius R [m]
-        Zmin, Zmax  - Range of height Z [m]
-
-        nx - Resolution in R. This must be 2^n + 1
-        ny - Resolution in Z. This must be 2^m + 1
-
-        boundary - The boundary condition, either freeBoundary or fixedBoundary
-
-        psi - Magnetic flux. If None, use concentric circular flux
-              surfaces as starting guess
-
-        current - Plasma current (default = 0.0)
-
-        order - The order of the differential operators to use.
-                Valid values are 2 or 4.
         """
+        Initializes a plasma equilibrium.
 
+        Parameters
+        ----------
+        tokamak : machine.Machine
+            The set of active coils, passive structures, limiter, and magnetic probes in the tokamak.
+        Rmin : float
+            Minimum major radius [m].
+        Rmax : float
+            Maximum major radius [m].
+        Zmin : float
+            Minimum height [m].
+        Zmax : float
+            Maximum height [m].
+        nx : int
+            Number of radial grid points (must be of form 2^n + 1, n=0,1,2,3,4,5,...).
+        ny : int
+            Number of vertical grid points (must be of form 2^n + 1, n=0,1,2,3,4,5,...).
+        boundary : callable
+            The boundary condition function. Can be either `freeBoundary`
+            or `fixedBoundary`.
+        psi : np.array
+            Initial guess for plasma flux. If `None`, default initial guess used.
+        current : float
+            Plasma current [A].
+        order : int
+            Order of differential operators used in calculations.
+            Must be either 2 or 4.
+        """
+        
+        # assign tokamak object
         self.tokamak = tokamak
 
-        self._applyBoundary = boundary
-
+        # assign bounds of computational domain
         self.Rmin = Rmin
         self.Rmax = Rmax
         self.Zmin = Zmin
         self.Zmax = Zmax
-
+        
+        # assign number of grid points
+        self.nx = nx
+        self.ny = ny
+        
+        # define 1D and 2D radial/vertical grids
         self.R_1D = linspace(Rmin, Rmax, nx)
         self.Z_1D = linspace(Zmin, Zmax, ny)
         self.R, self.Z = meshgrid(self.R_1D, self.Z_1D, indexing="ij")
 
+        # assign grid sizes
+        self.dR = self.R[1, 0] - self.R[0, 0]
+        self.dZ = self.Z[0, 1] - self.Z[0, 0]
+        
+        # assign boundary function
+        self._applyBoundary = boundary
+
+        # assign initial guess for plasma flux (if None)
         if psi is None:
             # Starting guess for psi
             psi = self.create_psi_plasma_default()
             self.gpars = np.array([0.5, 0.5, 0, 2])
         self.plasma_psi = psi
 
-        # Calculate coil Greens functions. This is an optimisation,
-        # used in self.psi() to speed up calculations
+        # generate Greens function mappings (used
+        # in self.psi() to speed up calculations)
         self._pgreen = tokamak.createPsiGreens(self.R, self.Z)
-
-        self._current = current  # Plasma current
-
         # self._updatePlasmaPsi(psi)  # Needs to be after _pgreen
 
-        # Create the solver
+        # assign plasma current
+        self._current = current
+
+        # deinfe the GS solver
         if order == 2:
             generator = GSsparse(Rmin, Rmax, Zmin, Zmax)
         elif order == 4:
@@ -142,147 +143,220 @@ class Equilibrium:
         )
 
     def create_psi_plasma_default(
-        self, adaptive_centre=False, gpars=(0.5, 0.5, 0, 2)
+        self, 
+        adaptive_centre=False, 
+        gpars=(0.5, 0.5, 0, 2)
     ):
-        """Creates a Gaussian starting guess for plasma_psi"""
-        nx, ny = np.shape(self.R)
+        """
+        Generate a Gaussian-shaped initial guess for the plasma flux.
+
+        The flux function ψ(R, Z) is given by:
+
+            ψ(R, Z) = exp(C - (|x - xc|^p + |y - yc|^p))
+
+        where (xc, yc) is the center, C is a shift, and p is a power term. 
+        The function ensures the flux is zero on the boundaries.
+
+        Parameters
+        ----------
+        adaptive_centre : bool, optional
+            If True, the plasma core position (xc, yc) is adjusted dynamically. 
+            If False (default), it remains fixed.
+        gpars : tuple (xc, yc, C, p)
+            Parameters defining the flux shape:
+            - xc, yc : float
+                Coordinates of the flux center.
+            - C : float
+                Shift parameter in the exponent.
+            - p : float
+                Power of the distance term.
+
+        Returns
+        -------
+        np.array
+            The computed flux values on the given (R, Z) grid.
+        """
+
+        # define unit meshgrid
         xx, yy = meshgrid(
-            linspace(0, 1, nx), linspace(0, 1, ny), indexing="ij"
+            linspace(0, 1, self.nx), linspace(0, 1, self.ny), indexing="ij"
         )
 
+        # finds approximate (weighted) centre of the core plasma
         if adaptive_centre == True:
             ntot = np.sum(self.mask_inside_limiter)
             xc = (
                 np.sum(
                     self.mask_inside_limiter
-                    * linspace(0, 1, nx)[:, np.newaxis]
+                    * linspace(0, 1, self.nx)[:, np.newaxis]
                 )
                 / ntot
             )
             yc = (
                 np.sum(
                     self.mask_inside_limiter
-                    * linspace(0, 1, ny)[np.newaxis, :]
+                    * linspace(0, 1, self.ny)[np.newaxis, :]
                 )
                 / ntot
             )
+        # else sets centre according to gpars
         else:
             xc, yc = gpars[:2]
+            
+        # generate the plasma flux
         psi = exp(
             gpars[2]
             - ((np.abs(xx - xc)) ** gpars[3] + (np.abs(yy - yc)) ** gpars[3])
         )
 
+        # set zero flux on boundary
         psi[0, :] = 0.0
         psi[:, 0] = 0.0
         psi[-1, :] = 0.0
         psi[:, -1] = 0.0
+        
         return psi
 
-    def setSolverVcycle(self, nlevels=1, ncycle=1, niter=1, direct=True):
+    def setSolverVcycle(self, 
+                        nlevels=1, 
+                        ncycle=1, 
+                        niter=1, 
+                        direct=True
+                        ):
         """
-        Creates a new linear solver, based on the multigrid code
+        Sets a new linear solver based on the multigrid scheme.
 
-        nlevels  - Number of resolution levels, including original
-        ncycle   - The number of V cycles
-        niter    - Number of linear solver (Jacobi) iterations per level
-        direct   - Use a direct solver at the coarsest level?
+        This method configures a multigrid V-cycle solver and assigns it to 
+        `self._solver`.
 
+        Parameters
+        ----------
+        nlevels : int
+            Number of resolution levels, including the original. 
+        ncycle : int
+            Number of V-cycles to use.
+        niter : int
+            Number of linear solver (Jacobi) iterations per level. 
+        direct : bool
+            If True, uses a direct solver at the coarsest level.
+
+        Returns
+        -------
+        None
+            This function modifies `self._solver` but does not return a value.
         """
-        generator = GSsparse(self.Rmin, self.Rmax, self.Zmin, self.Zmax)
-        nx, ny = self.R.shape
-
+        
+        # set the solver
         self._solver = multigrid.createVcycle(
-            nx,
-            ny,
-            generator,
+            nx=self.nx,
+            ny=self.ny,
+            generator=GSsparse(self.Rmin, self.Rmax, self.Zmin, self.Zmax),
             nlevels=nlevels,
             ncycle=ncycle,
             niter=niter,
             direct=direct,
         )
 
-    def setSolver(self, solver):
+    def setSolver(self, 
+                  solver
+                  ):
+
         """
         Sets the linear solver to use. The given object/function must have a __call__ method
-        which takes two inputs
+        which takes two inputs:
 
         solver(x, b)
 
-        where x is the initial guess. This should solve Ax = b, returning the result.
-
-        """
-        self._solver = solver
-
-    def callSolver(self, psi, rhs):
-        """
-        Calls the psi solver, passing the initial guess and RHS arrays
-
-        psi   Initial guess for the solution (used if iterative)
-        rhs
+        where x is the initial guess and b is the right hand side (thisshould solve Ax = b, 
+        returning the result).
+        
+                
+        Parameters
+        ----------
+        solver : object
+            The solver object.
 
         Returns
         -------
-
-        Solution psi
-
+        None
+            This function modifies `self._solver` but does not return a value.
         """
+        
+        self._solver = solver
+
+    def callSolver(self, 
+                   psi, 
+                   rhs
+                   ):
+        """
+        Calls the solver.
+        
+        Parameters
+        ----------
+        psi : np.array
+            The initial guess. 
+        rhs : np.array
+            The right hand side of the GS equation.
+
+        Returns
+        -------
+        object
+            Returns modified `self._solver` object.
+        """
+        
         return self._solver(psi, rhs)
 
     def getMachine(self):
         """
-        Returns the handle of the machine, including coils
+        Machine object.
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        object
+            Returns the tokamak object.
+
         """
+        
         return self.tokamak
 
     def plasmaCurrent(self):
         """
-        Plasma current [Amps]
+        Returns the plasma current [Amps].
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float
+            Returns the total plasma current [Amps].
+            
         """
+        
         return self._current
 
-    def poloidalBeta(self):
-        """
-        Return the poloidal beta
-        betap = (8pi/mu0) * int(p)dRdZ / Ip^2
-        """
-
-        dR = self.R[1, 0] - self.R[0, 0]
-        dZ = self.Z[0, 1] - self.Z[0, 0]
-
-        # Normalised psi
-        psi_norm = (self.psi() - self.psi_axis) / (
-            self.psi_bndry - self.psi_axis
-        )
-
-        # Plasma pressure
-        pressure = self.pressure(psi_norm)
-        try:
-            pressure *= self._profiles.limiter_core_mask
-        except AttributeError as e:
-            print(e)
-            warnings.warn(
-                "The core mask is not in place. You need to solve for the equilibrium first!"
-            )
-            raise e
-
-        # Integrate pressure in 2D
-        return (
-            ((8.0 * pi) / mu0)
-            * romb(romb(pressure))
-            * dR
-            * dZ
-            / (self.plasmaCurrent() ** 2)
-        )
-
     def plasmaVolume(self):
-        """Calculate the volume of the plasma in m^3"""
+        """
+        Plasma volume [m^3] calculated using:
+        
+            V = 2 * pi * integral(R) dR dZ,
+        
+        where the integral is evaluated over the plasma core domain.
+        
+        Parameters
+        ----------
 
-        dR = self.R[1, 0] - self.R[0, 0]
-        dZ = self.Z[0, 1] - self.Z[0, 0]
+        Returns
+        -------
+        float
+            Returns the total plasma volume [m^3].
+        """
 
-        # Volume element
-        dV = 2.0 * pi * self.R * dR * dZ
+        # volume element
+        dV = 2.0 * pi * self.R * self.dR * self.dZ
 
         try:
             dV *= self._profiles.limiter_core_mask
@@ -293,48 +367,146 @@ class Equilibrium:
             )
             raise e
 
-        # Integrate volume in 2D
+        # integrate volume in 2D
         return romb(romb(dV))
 
-    def plasmaBr(self, R, Z):
+    def plasmaBr(self, 
+                 R, 
+                 Z
+                 ):
         """
-        Radial magnetic field due to plasma
-        Br = -1/R dpsi/dZ
+        Radial magnetic field due to plasma:
+        
+            Br_p(R, Z) = -(1 / R) * dψ_p/dZ (R, Z),
+            
+        where ψ_p is the plasma flux. 
+        
+        Parameters
+        ----------
+        R : float or np.array
+            Radial position(s) to evaluate at.
+        Z : float or np.array
+            Vertical position(s) to evaluate at.
+            
+        Returns
+        -------
+        float or np.array
+            The radial magnetic field due to the plasma at the given (R, Z) positions.
         """
+
         return -self.psi_func(R, Z, dy=1, grid=False) / R
 
-    def plasmaBz(self, R, Z):
+    def plasmaBz(self, 
+                 R, 
+                 Z
+                 ):
+        """        
+        Vertical magnetic field Bz due to plasma::
+        
+            Bz_p(R, Z) = (1 / R) * dψ/dR (R, Z),
+        
+        where ψ_p is the plasma flux.
+        
+        Parameters
+        ----------
+        R : float or np.array
+            Radial position(s) to evaluate at.
+        Z : float or np.array
+            Vertical position(s) to evaluate at.
+        
+        Returns
+        -------
+        float or np.array
+            The vertical magnetic field due to the plasma at the given (R, Z) positions.
         """
-        Vertical magnetic field due to plasma
-        Bz = (1/R) dpsi/dR
-        """
+
         return self.psi_func(R, Z, dx=1, grid=False) / R
 
-    def Br(self, R, Z):
+    def Br(self, 
+           R, 
+           Z
+           ):
         """
-        Total radial magnetic field
+        Total radial magnetic field due to plasma and coils:
+        
+            Br(R, Z) = -(1 / R) * dψ/dZ (R, Z),
+            
+        where ψ is the total flux. 
+        
+        Parameters
+        ----------
+        R : float or np.array
+            Radial position(s) to evaluate at.
+        Z : float or np.array
+            Vertical position(s) to evaluate at.
+            
+        Returns
+        -------
+        float or np.array
+            The total radial magnetic field at the given (R, Z) positions.
         """
+        
         return self.plasmaBr(R, Z) + self.tokamak.Br(R, Z)
 
-    def Bz(self, R, Z):
+    def Bz(self, 
+           R, 
+           Z
+           ):
         """
-        Total vertical magnetic field
+        Total vertical magnetic field due to plasma and coils:
+        
+            Bz(R, Z) = (1 / R) * dψ/dR (R, Z),
+            
+        where ψ is the total flux. 
+        
+        Parameters
+        ----------
+        R : float or np.array
+            Radial position(s) to evaluate at.
+        Z : float or np.array
+            Vertical position(s) to evaluate at.
+
+        Returns
+        -------
+        float or np.array
+            The total vertical magnetic field at the given (R, Z) positions.
         """
+        
         return self.plasmaBz(R, Z) + self.tokamak.Bz(R, Z)
 
-    def Btor(self, R, Z):
+    def Btor(self, 
+             R, 
+             Z
+             ):
         """
-        Toroidal magnetic field
+        Total toroidal magnetic field:
+        
+            Btor(R, Z) = I(R, Z) * fpol(ψ_n) + (1 - I(R, Z)) * fvac,
+            
+        where:
+            - I(R, Z) = 1 inside core plasma, 0 outside.
+            - fpol = R*Bt at specified values of normalised psi ψ_n (i.e.
+        inside the plasma core).
+            - fvac = = R*Bt in vacuum (i.e. outside plasma). 
+        
+        Parameters
+        ----------
+        R : float or np.array
+            Radial position(s) to evaluate at.
+        Z : float or np.array
+            Vertical position(s) to evaluate at.
+            
+        Returns
+        -------
+        float or np.array
+            The toroidal magnetic field at the given (R, Z) positions.
         """
-        # Normalised psi
-        psi_norm = (self.psiRZ(R, Z) - self.psi_axis) / (
-            self.psi_bndry - self.psi_axis
-        )
 
-        # Get f = R * Btor in the core. May be invalid outside the core
-        fpol = self.fpol(psi_norm)
+        # find f = R * Btor in the core
+        fpol = self.fpol(self.psiNRZ(self.R, self.Z))
 
         try:
+            # combine values in core plasma with vacuum field outside
             fpol = (
                 fpol * self._profiles.limiter_core_mask
                 + (1.0 - self._profiles.limiter_core_mask) * self.fvac()
@@ -345,87 +517,1401 @@ class Equilibrium:
                 "The core mask is not in place. You need to solve for the equilibrium first!"
             )
             raise e
+        
+        # interpolate over the field
+        func = interpolate.RectBivariateSpline(self.R_1D, self.Z_1D, fpol/self.R)
+        
+        # if inputs are scalars, return scalar
+        if np.isscalar(R) and np.isscalar(Z):
+            return func(R, Z)[0, 0]
+        elif R.ndim == 1 and Z.ndim == 1:
+            return func(R.flatten(), Z.flatten(), grid=False)
+        elif R.ndim == 2 and Z.ndim == 2:
+            return func(R, Z, grid=False)
+        else:
+            raise ValueError("Unexpected input shape for R and Z.")
 
-        return fpol / R
+
+    def Bpol(self, 
+           R, 
+           Z
+           ):
+        """
+        Total poloidal magnetic field due to plasma and coils:
+        
+            Bpol(R, Z) = ( Br(R, Z)^2 + Bz(R, Z)^2 )^(1/2).
+        
+        Parameters
+        ----------
+        R : float or np.array
+            Radial position(s) to evaluate at.
+        Z : float or np.array
+            Vertical position(s) to evaluate at.
+
+        Returns
+        -------
+        float or np.array
+            The poloidal magnetic field at the given (R, Z) positions.
+        """
+        
+        Br = self.Br(R, Z)
+        Bz = self.Bz(R, Z)
+        
+        return np.sqrt( (Br*Br) + (Bz*Bz) )
+    
 
     def psi(self):
         """
-        Total poloidal flux ψ (psi), including contribution from
-        plasma and external coils.
+        Total poloidal flux due to plasma and coils on the
+        entire (R,Z) grid:
+        
+            ψ(R, Z) = ψ_p (R, Z) + ψ_c (R, Z),
+            
+        where:
+         -  ψ_p (R, Z) is the plasma flux. 
+         -  ψ_c (R, Z) is the coil flux.
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        np.array
+            The total poloidal flux due to the plasma and the coils.          
         """
-        # return self.plasma_psi + self.tokamak.psi(self.R, self.Z)
+
         return self.plasma_psi + self.tokamak.calcPsiFromGreens(self._pgreen)
 
-    def psiRZ(self, R, Z):
+    def psiRZ(self, 
+              R, 
+              Z
+              ):
         """
-        Return poloidal flux psi at given (R,Z) location
+        Total poloidal flux due to plasma and coils (at chosen R and Z):
+        
+            ψ(R, Z) = ψ_p (R, Z) + ψ_c (R, Z),
+            
+        where:
+         -  ψ_p (R, Z) is the plasma flux. 
+         -  ψ_c (R, Z) is the coil flux.
+        
+        Parameters
+        ----------
+        R : float or np.array
+            Radial position(s) to evaluate at.
+        Z : float or np.array
+            Vertical position(s) to evaluate at.
+
+        Returns
+        -------
+        float or np.array
+            The total poloidal flux due to the plasma and the coils at chosen (R,Z) locations. 
         """
+        
         return self.psi_func(R, Z, grid=False) + self.tokamak.psi(R, Z)
 
-    def fpol(self, psinorm):
+    def psiNRZ(self, 
+              R, 
+              Z
+              ):
         """
-        Return f = R*Bt at specified values of normalised psi
+        Total poloidal flux due to plasma and coils (at chosen R and Z), normalised
+        with respect to the flux on the magnetic axis and last closed flux surface:
+        
+            ψ_n(R, Z) = (ψ(R, Z) - ψ_a)/(ψ_b - ψ_a),
+            
+        where:
+         -  ψ_a is the total flux on the magnetic axis. 
+         -  ψ_b is the total flux on the last closed flux surface. 
+        
+        Parameters
+        ----------
+        R : float or np.array
+            Radial position(s) to evaluate at.
+        Z : float or np.array
+            Vertical position(s) to evaluate at.
+
+        Returns
+        -------
+        float or np.array
+            The total normalised poloidal flux due to the plasma and the coils at chosen (R,Z) locations.
         """
+        
+        return (self.psiRZ(R, Z) - self.psi_axis) / (self.psi_bndry - self.psi_axis)
+    
+    def psi_1D(self,
+               N
+               ):
+        """
+        Total poloidal flux between magnetic axis and last closed flux surface (at 
+        equally spaced locations).
+        
+        Parameters
+        ----------
+        N : int
+            Number of discretisation points.
+
+        Returns
+        -------
+        np.array
+            The total poloidal flux due to the plasma and the coils between the magnetic axis
+            and last closed flux surface.
+        """
+
+        return  np.linspace(self.psi_axis, self.psi_bndry, N)
+
+    def psiN_1D(self,
+               N
+               ):
+        """
+        Total normalised poloidal flux between magnetic axis and last closed flux surface.
+        
+        Parameters
+        ----------
+        N : int
+            Number of discretisation points. 
+
+        Returns
+        -------
+        np.array
+            The total normalised poloidal flux due to the plasma and the coils between the magnetic axis
+            and last closed flux surface.
+        """
+
+        return  np.linspace(0, 1, N)
+    
+    def rho_1D(self,
+            N,
+            ):
+        """
+        Toroidal flux ρ (at locations of normalised psi) such that:
+        
+            ρ = Φ(ψ) and
+        
+            Φ = - (1/(2 * pi)) integral(q(ψ)) dψ,
+            
+        where:
+         - q is the safety factor profile as a function of ψ. 
+        
+        Parameters
+        ----------
+        N : int
+            Number of discretisation points.
+            
+        Returns
+        -------
+        np.array
+            The toroidal flux (at locations of normalised psi).
+        """
+
+        # calculate safety factor of the (normalised) flux surfaces
+        qvals = self.q(self.psiN_1D(N))
+
+        # compute the integral (cumulatively)
+        integral = (-1.0 / (2.0 * np.pi)) * cumulative_trapezoid(qvals, self.psi_1D(N), initial=0.0)
+        integral[0] = 0 # hard-code for floating point issues
+        
+        # convert to a scalar if only single output
+        if len(integral) == 1:
+            return integral[0] 
+        return integral
+        
+    def rhoN_1D(self,
+            N
+            ):
+        """
+        Normalised toroidal flux ρ_n (at locations of normailsed psi) such that:
+        
+        ρ_n = sqrt( ρ / ρ_b ),
+            
+        where ρ_b is the toridal flux at the last closed flux surface.
+        
+        Parameters
+        ----------
+        N : int
+            Number of discretisation points.
+
+        Returns
+        -------
+        np.array
+            The normalised toroidal flux (at locations of normalised psi).
+        """
+
+        # calculate rho
+        rho = self.rho_1D(N)
+
+        return np.sqrt(rho/rho[-1])
+    
+    def fpol(self, 
+             psinorm
+             ):
+        """
+        Return f = R*Bt at specified values of normalised psi (i.e.
+        inside the plasma core).
+        
+        Parameters
+        ----------
+        psinorm : np.array
+            Array of normalised psi values between 0 and 1.
+            
+        Returns
+        -------
+        np.array
+            fpol at values of normalised psi.
+        """
+        
         return self._profiles.fpol(psinorm)
 
     def fvac(self):
         """
-        Return vacuum f = R*Bt
+        Return vacuum f = R*Bt (i.e. outside the plasma core). 
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float
+            fvac value in vacuum. 
         """
+        
         return self._profiles.fvac()
 
-    def q(self, psinorm=None, npsi=100):
+    def q(self, 
+          psinorm
+          ):
         """
-        Returns safety factor q at specified values of normalised psi
-
-        psinorm is a scalar, list or array of floats betweem 0 and 1.
-
-        >>> safety_factor = eq.q([0.2, 0.5, 0.9])
-
-        If psinorm is None, then q on a uniform psi grid will be returned,
-        along with the psi values
-
-        >>> psinorm, q = eq.q()
-
-        Note: psinorm = 0 is the magnetic axis, and psinorm = 1 is the separatrix.
-              Calculating q on either of these flux surfaces is problematic,
-              and the results will probably not be accurate.
+        Safety factor q at normalised flux values. 
+        
+        Note that at both psinorm = 0 (magnetic axis) and psinorm = 1 (separatrix),
+        calculating q is problematic (results may be inaccurate).
+        
+        Parameters
+        ----------
+        psinorm : np.array
+            Array of normalised psi values between (not including) 0 and 1.
+            
+        Returns
+        -------
+        np.array
+            Safety factor q at values of normalised psi.
         """
-        if psinorm is None:
-            # An array which doesn't include psinorm = 0 or 1
-            psinorm = linspace(1.0 / (npsi + 1), 1.0, npsi, endpoint=False)
-            return psinorm, critical.find_safety(self, psinorm=psinorm)
+        
+        # print warning if needed
+        if 0 in psinorm or 1 in psinorm:
+            print("psinorm contains 0 or 1, which may cause numerical issues druing safety factor calculation.")
+            
+        # find safety factor profile
+        q = critical.find_safety(self, psinorm=psinorm)
+        
+        # convert to a scalar if only single output
+        if len(q) == 1:
+            return np.asscalar(q)
+        
+        return q
 
-        result = critical.find_safety(self, psinorm=psinorm)
-        # Convert to a scalar if only one result
-        if len(result) == 1:
-            return np.asscalar(result)
-        return result
+    def pprime(self, 
+               psinorm
+               ):
+        """
+        Return pprime (dp/dψ_n) at normalised flux values. 
+        
+        Parameters
+        ----------
+        psinorm : np.array
+            Array of normalised psi values between (not including) 0 and 1.
 
-    def pprime(self, psinorm):
+        Returns
+        -------
+        np.array
+            pprime (dp/dψ_n) at normalised flux values. 
         """
-        Return p' at given normalised psi
-        """
+
         return self._profiles.pprime(psinorm)
 
-    def ffprime(self, psinorm):
+    def ffprime(self, 
+                psinorm
+                ):
         """
-        Return ff' at given normalised psi
+        Return ffprime (F * dF/dψ_n) at normalised flux values. 
+        
+        Parameters
+        ----------
+        psinorm : np.array
+            Array of normalised psi values between (not including) 0 and 1.
+            
+        Returns
+        -------
+        np.array
+            ffprime (F * dF/dψ_n) at normalised flux values. 
         """
+        
         return self._profiles.ffprime(psinorm)
 
-    def pressure(self, psinorm, out=None):
+    def pressure(self, 
+                 psinorm
+                 ):
         """
-        Returns plasma pressure at specified values of normalised psi
+        Return pressure (p(ψ_n)) at normalised flux values. 
+        
+        Parameters
+        ----------
+        psinorm : np.array
+            Array of normalised psi values between (not including) 0 and 1.
+            
+        Returns
+        -------
+        np.array
+            pressure (p(ψ_n)) at normalised flux values. 
         """
+        
         return self._profiles.pressure(psinorm)
 
-    def separatrix(self, ntheta=20):
+    def separatrix(self, 
+                   ntheta=360
+                   ):
         """
-        Returns an array of ntheta (R, Z) coordinates of the separatrix,
-        equally spaced in geometric poloidal angle.
+        Return (ntheta x 2) array of (R,Z) points on the last closed 
+        flux surface (plasma boundary), equally spaced in the geometric 
+        poloidal angle. 
+        
+        Parameters
+        ----------
+        ntheta : int
+            Number of points on the boundary to return.
+
+        Returns
+        -------
+        np.array
+            (R,Z) points on the last closed flux surface (plasma boundary). 
         """
+        
         return array(critical.find_separatrix(self, ntheta=ntheta))[:, 0:2]
+
+    def separatrix_area(self):
+        """
+        The area of the last closed flux surface [m^2].
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float
+            Area of the last closed flux surface (plasma boundary). 
+        """
+
+        Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
+
+        return area
+    
+    def separatrix_length(self):
+        """
+        The circumference of the last closed flux surface [m].
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float
+            Circumference of the last closed flux surface (plasma boundary). 
+        """
+
+        Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
+
+        return length
+
+    def separatrix_metrics(
+        self
+        ):
+        """
+        Function that returns min/max (R,Z) points on the last closed flux surface,
+        its area, and its circumference. 
+
+        Depiction here: https://imas-data-dictionary.readthedocs.io/en/latest/_downloads/23716946c6f02da1817f55b2f453444d/DefinitionEqBoundary.svg
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float x 8
+            List of core boundary extrema Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax [m].
+        float
+            The area of the core plasma boundary [m^2].
+        float
+            The circumference of the core plasma boundary [m].
+        """
+
+        # calculate core separatrix
+        core_boundary = self.separatrix()
+
+        # min/max values on core boundary
+        Rmin = np.min(core_boundary[:, 0])
+        Rmax = np.max(core_boundary[:, 0])
+        Zmin = np.min(core_boundary[:, 1])
+        Zmax = np.max(core_boundary[:, 1])
+
+        # find corresponding indices for these
+        ZRmin_arg = np.argmin(core_boundary[:, 0])
+        ZRmax_arg = np.argmax(core_boundary[:, 0])
+        RZmin_arg = np.argmin(core_boundary[:, 1])
+        RZmax_arg = np.argmax(core_boundary[:, 1])
+
+        # use indices to find corresponding coords
+        ZRmin = core_boundary[ZRmin_arg, 1]
+        ZRmax = core_boundary[ZRmax_arg, 1]
+        RZmin = core_boundary[RZmin_arg, 0]
+        RZmax = core_boundary[RZmax_arg, 0]
+
+        # use shapely to define polygon of core plasma
+        plasma_polygon = sh.Polygon(core_boundary)
+        area = plasma_polygon.area
+        length = plasma_polygon.length
+
+        
+        return Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length
+    
+    def getForces(self):
+        """
+        Calculates the forces on the coils.3
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        dict
+            Coil lables with the associated force.  
+        """
+        
+        return self.tokamak.getForces(self)
+
+    def printForces(self):
+        """
+        Prints a table of forces on coils.
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        None
+            Table of forces on coils. 
+        """        
+        
+        print("Forces on coils")
+
+        def print_forces(forces, prefix=""):
+            for label, force in forces.items():
+                if isinstance(force, dict):
+                    print(prefix + label + " (circuit)")
+                    print_forces(force, prefix=prefix + "  ")
+                else:
+                    print(
+                        prefix
+                        + label
+                        + " : R = {0:.2f} kN , Z = {1:.2f} kN".format(
+                            force[0] * 1e-3, force[1] * 1e-3
+                        )
+                    )
+
+        print_forces(self.getForces())
+
+    def innerOuterSeparatrix(
+        self, 
+        Z: float = 0.0, 
+        ):
+        """
+        Locate inboard and outboard R co-ordinates of last closed flux surface 
+        at a given Z position.
+        
+        Parameters
+        ----------
+        Z : float, optional
+            The Z value at which to find the radii. Defaults to
+            0.0.
+
+        Returns
+        -------
+        float
+            The inner separatrix major radius (at chosen Z).
+        float
+            The outer separatrix major radius (at chosen Z).
+        """
+        
+        # Find the closest index to requested Z
+        Zindex = np.argmin(abs(self.Z[0, :] - Z))
+
+        # Normalise psi at this Z index
+        psinorm = (self.psi()[:, Zindex] - self.psi_axis) / (
+            self.psi_bndry - self.psi_axis
+        )
+
+        # Start from the magnetic axis
+        Rindex_axis = np.argmin(abs(self.R[:, 0] - self.Rmagnetic()))
+
+        # Inner separatrix
+        # Get the maximum index where psi > 1 in the R index range from 0 to Rindex_axis
+        outside_inds = np.argwhere(psinorm[:Rindex_axis] > 1.0)
+
+        if outside_inds.size == 0:
+            R_in = self.Rmin
+        else:
+            Rindex_inner = np.amax(outside_inds)
+
+            # Separatrix should now be between Rindex_inner and Rindex_inner+1
+            # Linear interpolation
+            R_in = (
+                self.R[Rindex_inner, Zindex]
+                * (1.0 - psinorm[Rindex_inner + 1])
+                + self.R[Rindex_inner + 1, Zindex]
+                * (psinorm[Rindex_inner] - 1.0)
+            ) / (psinorm[Rindex_inner] - psinorm[Rindex_inner + 1])
+
+        # Outer separatrix
+        # Find the minimum index where psi > 1
+        outside_inds = np.argwhere(psinorm[Rindex_axis:] > 1.0)
+
+        if outside_inds.size == 0:
+            R_out = self.Rmax
+        else:
+            Rindex_outer = np.amin(outside_inds) + Rindex_axis
+
+            # Separatrix should now be between Rindex_outer-1 and Rindex_outer
+            R_out = (
+                self.R[Rindex_outer, Zindex]
+                * (1.0 - psinorm[Rindex_outer - 1])
+                + self.R[Rindex_outer - 1, Zindex]
+                * (psinorm[Rindex_outer] - 1.0)
+            ) / (psinorm[Rindex_outer] - psinorm[Rindex_outer - 1])
+
+        return R_in, R_out
+
+    def innerOuterSeparatrix2(
+        self, 
+        Z=0.0, 
+        ):
+        """
+        Alternative (simpler) function to find inboard and outboard R co-ordinates of 
+        last closed flux surface at any given Z position (using shapely).
+        
+        Parameters
+        ----------
+        Z : float, optional
+            The Z value at which to find the radii. Defaults to
+            0.0.
+
+        Returns
+        -------
+        list
+            List with the two (R,Z) coordinates: (R_in, Z) and (R_out, Z). 
+        """
+        
+        # use shapely to define polygon of core plasma
+        plasma_polygon = sh.LinearRing(self.separatrix(ntheta=360))
+        
+        # use shapely to define horizonal line at Z
+        Z_line = sh.LineString([[0 ,Z], [100, Z]])
+        
+        # find intersection
+        intersection = plasma_polygon.intersection(Z_line)
+
+        # extract coordinates
+        if intersection.is_empty:
+            print("No intersection found.")
+            intersection_coords = []
+        elif intersection.geom_type == "Point":
+            intersection_coords = [intersection.coords[0]]  # Single point
+        elif intersection.geom_type == "MultiPoint":
+            intersection_coords = [pt.coords[0] for pt in intersection.geoms]  # Multiple points
+        else:
+            raise ValueError(f"Unexpected intersection type: {intersection.geom_type}")
+
+        return intersection_coords
+
+    def intersectsWall(self):
+        """
+        Assess whether or not the core plasma touches the vessel
+        walls.
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        bool 
+            True if they interect, False if not.       
+        """
+        
+        # generate list of points for each
+        separatrix = self.separatrix()
+        wall = self.tokamak.wall
+
+        return polygons.intersect(
+            separatrix[:, 0], separatrix[:, 1], wall.R, wall.Z
+        )
+
+    def magneticAxis(self):
+        """
+        Returns the location of the magnetic axis and its total poloidal flux value. 
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        list 
+            Returns [R, Z, ψ(R, Z)] at magnetic axis location.       
+        """
+        
+        opt, xpt = critical.find_critical(self.R, self.Z, self.psi())
+        
+        return opt[0]
+
+    def Rmagnetic(self):
+        """
+        The major radius of the magnetic axis. 
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Major radius of the magnetic axis [m].
+        """
+        
+        return self.magneticAxis()[0]
+
+    def Zmagnetic(self):
+        """
+        The height of the magnetic axis. 
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Vertical height of the magnetic axis [m].
+        """
+        
+        return self.magneticAxis()[1]
+    
+    def geometricAxis(self):
+        """
+        The geometric axis (R_geom, Z_geom) of the plasma [m]. Calculated as
+        the centre of a large number of points on the separatrix.
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        np.array 
+            Geometric axis (R,Z) position [m].
+        """
+
+        Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
+        
+        return np.array([(Rmax + Rmin) / 2, (Zmax + Zmin) / 2])
+
+    def Rgeometric(self):
+        """
+        The major radius of the geometric axis. 
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Major radius of the geometric axis [m].
+        """
+        
+        return self.geometricAxis()[0]
+
+    def Zgeometric(self):
+        """
+        The height of the geometric axis. 
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Vertical height of the geometric axis [m].
+        """
+        
+        return self.geometricAxis()[1]
+    
+    def minorRadius(self):
+        """
+        Calculate the minor radius of the plasma [m].
+            
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Minor radius of the plasma [m].
+        """
+
+        Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
+        
+        return (Rmax - Rmin) / 2
+    
+    def aspectRatio(self):
+        """
+        Calculate the aspect ratio of the plasma.
+            
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Aspect ratio of the plasma.
+        """
+        
+        Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
+
+        return (Rmax + Rmin) / (Rmax - Rmin)
+    
+    def geometricElongation(self):
+        """
+        Calculate the geometric elongation of the plasma.
+            
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Geometric elongation of the plasma.
+        """
+
+        Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
+        
+        return (Zmax - Zmin) / (Rmax - Rmin)
+
+    def geometricElongation_upper(self):
+        """
+        Calculate the geometric elongation of the upper part of the plasma.
+            
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Geometric elongation of the upper part of the plasma.
+        """
+
+        Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
+        
+        return 2 * (Zmax - ZRmax) / (Rmax - Rmin)
+    
+    def geometricElongation_lower(self):
+        """
+        Calculate the geometric elongation of the lower part of the plasma.
+            
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Geometric elongation of the lower part of the plasma.
+        """
+
+        Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
+        
+        return 2 * (ZRmax - Zmin) / (Rmax - Rmin)
+    
+    
+    def effectiveElongation(self):
+        """
+        Calculate the effective elongation of the plasma, using plasma volume.
+            
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Effective elongation of the plasma.
+        """
+            
+        Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
+
+        R_geom = (Rmax + Rmin) / 2
+        R_minor = (Rmax - Rmin) / 2
+        
+        return self.plasmaVolume() / (2.0 * R_geom * (np.pi ** 2) * (R_minor ** 2))
+
+    def shafranov_shift(self):
+        """
+        Calculate the Shafranov shift of the plasma (i.e. the shift between the magnetic
+        axis and the geometrix axis).
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Shafranov shift of the plasma [del_R, del_Z] [m].
+        """
+        
+        mag_axis = self.magneticAxis()
+        geom_axis = self.geometricAxis()
+                
+        return np.array([mag_axis[0] - geom_axis[0], mag_axis[1] - geom_axis[1]])
+    
+    def triangularity_upper(self):
+        """
+        Calculate the upper triangularity of the plasma.
+            
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Upper triangularity of the plasma.
+        """
+
+        Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
+        R_geom = (Rmax + Rmin) / 2
+        R_minor = (Rmax - Rmin) / 2
+
+        return (R_geom  - RZmin) / R_minor
+    
+    def triangularity_lower(self):
+        """
+        Calculate the lower triangularity of the plasma.
+            
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Lower triangularity of the plasma.
+        """
+
+        Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
+        R_geom = (Rmax + Rmin) / 2
+        R_minor = (Rmax - Rmin) / 2
+
+        return (R_geom  - RZmax) / R_minor
+
+    def triangularity(self):
+        """
+        Calculate the triangularity of the plasma.
+            
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float 
+            Triangularity of the plasma.
+        """
+
+        Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
+        R_geom = (Rmax + Rmin) / 2
+        R_minor = (Rmax - Rmin) / 2
+
+        return ( R_geom  - (RZmax + RZmin)/2 )  / R_minor
+
+    def squareness(self):
+        """
+        This function calculates the squareness of the plasma core for each of the four quadrants:
+        upper outer, upper lower, lower outer, and lower inner. Method outlined in:
+
+        An analytic functional form for characterization and generation of axisymmetric plasma
+        boundaries. Plasma Physics and Controlled Fusion. 2013. T C Luce.
+            
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float
+            Upper outer squareness. 
+        float
+            Upper inner squareness. 
+        float
+            Lower outer squareness. 
+        float
+            Lower inner squareness. 
+        """
+
+        # find separatrix metrics
+        Rmin, Rmax, Zmin, Zmax, ZRmin, ZRmax, RZmin, RZmax, area, length = self.separatrix_metrics()
+
+        # create shapely object for plasma core
+        plasma_boundary = sh.Polygon(self.separatrix())
+
+        # same for "ideal" ellipses in each quadrant
+        uo_ellipse = sh.Polygon(
+            ellipse_points(R0=RZmax, Z0=ZRmax, A=Rmax - RZmax, B=Zmax - ZRmax)
+        )
+        ui_ellipse = sh.Polygon(
+            ellipse_points(R0=RZmax, Z0=ZRmax, A=RZmax - Rmin, B=Zmax - ZRmax)
+        )
+        lo_ellipse = sh.Polygon(
+            ellipse_points(R0=RZmin, Z0=ZRmax, A=Rmax - RZmin, B=ZRmax - Zmin)
+        )
+        li_ellipse = sh.Polygon(
+            ellipse_points(R0=RZmin, Z0=ZRmax, A=RZmin - Rmin, B=ZRmax - Zmin)
+        )
+
+        # bounding box diagonals
+        uo_diag = sh.LineString([[RZmax, ZRmax], [Rmax, Zmax]])
+        ui_diag = sh.LineString([[RZmax, ZRmax], [Rmin, Zmax]])
+        lo_diag = sh.LineString([[RZmin, ZRmax], [Rmax, Zmin]])
+        li_diag = sh.LineString([[RZmin, ZRmax], [Rmin, Zmin]])
+
+        # find intersecting line lengths
+        uo_diag_core = uo_diag.intersection(plasma_boundary).length
+        ui_diag_core = uo_diag.intersection(plasma_boundary).length
+        lo_diag_core = uo_diag.intersection(plasma_boundary).length
+        li_diag_core = uo_diag.intersection(plasma_boundary).length
+
+        uo_diag_ellipse = uo_diag.intersection(uo_ellipse).length
+        ui_diag_ellipse = uo_diag.intersection(ui_ellipse).length
+        lo_diag_ellipse = uo_diag.intersection(lo_ellipse).length
+        li_diag_ellipse = uo_diag.intersection(li_ellipse).length
+
+        # calculate squarenesses
+        s_uo = (uo_diag_core - uo_diag_ellipse) / (uo_diag.length - uo_diag_ellipse)
+        s_ui = (ui_diag_core - ui_diag_ellipse) / (ui_diag.length - ui_diag_ellipse)
+        s_lo = (lo_diag_core - lo_diag_ellipse) / (lo_diag.length - lo_diag_ellipse)
+        s_li = (li_diag_core - li_diag_ellipse) / (li_diag.length - li_diag_ellipse)
+        
+        return s_uo, s_ui, s_lo, s_li
+    
+    def closest_wall_point(self):
+        """
+        This function calculates the (R,Z) point on the wall that is closest 
+        to the last closed flux surface boundary (and the corresponding distance).
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        list
+            Contains coordinates array and minimum distance to wall: [ (R,Z), min_distance ].
+        """
+
+        # create shapely linestring objects
+        plasma_boundary = sh.LineString(self.separatrix())
+        wall = sh.LineString(np.array([self.tokamak.wall.R, self.tokamak.wall.Z]).T)
+
+        # initialize variables
+        closest_point = None
+        min_distance = float("inf")
+
+        # iterate over each point on the wall contour
+        for point_coords in wall.coords:
+            wall_point = sh.Point(point_coords)
+
+            # calculate distance from wall point to plasma boundary
+            initial_distance = plasma_boundary.distance(wall_point)
+
+            if initial_distance < min_distance:
+                # find the closest point on the plasma boundary
+                candidate_closest_point = plasma_boundary.interpolate(
+                    plasma_boundary.project(wall_point)
+                )
+
+                # recalculate the distance between the wall point and the closest point (due to interpolation)
+                corrected_distance = wall_point.distance(candidate_closest_point)
+
+                if corrected_distance < min_distance:
+                    min_distance = corrected_distance
+                    closest_point = candidate_closest_point
+
+        return [np.array(closest_point.coords[0]) , min_distance]
+
+    def internalInductance1(self):
+        """
+        Calculates li1 plasma internal inductance according to:
+        
+            li_1 = [(2 * integral(Bpol^2) dV) / (mu0 * Ip^2 * R_geom)] * [(1 + geom_elon^2)/(2 * eff_elon)],
+    
+        where:
+         - Bpol(R,Z) = poloidal magnetic field (at each (R,Z)).
+         - dV = volume element. 
+         - mu0 = magnetic permeability in vacuum.
+         - Ip = total plasma current.
+         - R_geom = radial coords of geometric axis. 
+         - geom_elon = geometric elongation.
+         - eff_elon = effective elongation. 
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float
+            Plasma internal inductance (li1). 
+        """
+
+        # extract Bpol squared
+        B_pol_2 = self.Bpol(self.R, self.Z)**2
+
+        # volume elements
+        dV = 2.0 * np.pi * self.R * self.dR * self.dZ
+
+        # mask with the core plasma 
+        try:
+            dV *= self._profiles.limiter_core_mask 
+        except AttributeError as e:
+            print(e)
+            warnings.warn(
+                "The core mask is not in place. You need to solve for the equilibrium first!"
+            )
+            raise e
+
+        # integrate B_pol squared over the volume
+        integral = romb(romb(B_pol_2 * dV))
+        
+        return ((2 * integral) / ((mu0 * self.plasmaCurrent()) ** 2 * self.Rgeometric())) * ((1 + self.geometricElongation()**2) / (2.0 * self.effectiveElongation()))
+
+    def internalInductance2(self):
+        """
+        Calculates li2 plasma internal inductance according to:
+        
+            li_2 = (2 * integral(Bpol^2) dV) / (mu0 * Ip^2 * R_mag),
+            
+        where:
+         - Bpol(R,Z) = poloidal magnetic field (at each (R,Z)).
+         - dV = volume element. 
+         - mu0 = magnetic permeability in vacuum.
+         - Ip = total plasma current.
+         - R_mag = radial coords of magnetic axis. 
+         
+         
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float
+            Plasma internal inductance (li2). 
+        """
+        
+        # extract Bpol squared
+        B_pol_2 = self.Bpol(self.R, self.Z)**2
+
+        # volume elements
+        dV = 2.0 * np.pi * self.R * self.dR * self.dZ
+
+        # mask with the core plasma 
+        try:
+            dV *= self._profiles.limiter_core_mask
+        except AttributeError as e:
+            print(e)
+            warnings.warn(
+                "The core mask is not in place. You need to solve for the equilibrium first!"
+            )
+            raise e
+
+        # integrate B_pol squared over the volume
+        integral = romb(romb(B_pol_2 * dV))
+        
+        return 2 * integral / ((mu0 * self.plasmaCurrent()) ** 2 * self.Rmagnetic())
+
+    def internalInductance3(self):
+        """
+        Calculates li3 plasma internal inductance according to:
+        
+            li_3 = (2 * integral(Bpol^2) dV) / (mu0 * Ip^2 * R_geom),
+            
+            
+        where:
+         - Bpol(R,Z) = poloidal magnetic field (at each (R,Z)).
+         - dV = volume element. 
+         - mu0 = magnetic permeability in vacuum.
+         - Ip = total plasma current.
+         - R_geom = radial coords of geometric axis. 
+         
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float
+            Plasma internal inductance (li3). 
+        """
+        
+        # extract Bpol squared
+        B_pol_2 = self.Bpol(self.R, self.Z)**2
+
+        # volume elements
+        dV = 2.0 * np.pi * self.R * self.dR * self.dZ
+
+        # mask with the core plasma 
+        try:
+            dV *= self._profiles.limiter_core_mask
+        except AttributeError as e:
+            print(e)
+            warnings.warn(
+                "The core mask is not in place. You need to solve for the equilibrium first!"
+            )
+            raise e
+
+        # integrate B_pol squared over the volume
+        integral = romb(romb(B_pol_2 * dV))
+        
+        return 2 * integral / ((mu0 * self.plasmaCurrent()) ** 2 * self.Rgeometric())
+
+    def poloidalBeta(self):
+        """
+        Calculates the poloidal beta from the following definition:
+        
+            betap = (8 * pi / (mu0 * Ip^2)) * integral(p) dR dZ,
+        
+        where:
+         - mu0 = magnetic permeability in vacuum.
+         - Ip = total plasma current.
+         - p = plasma pressure (at each (R,Z)).
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float
+            Returns the poloidal beta value.
+        """
+        
+        # plasma pressure
+        pressure = self.pressure(self.psiNRZ(self.R, self.Z))
+        
+        # mask with the core plasma 
+        try:
+            pressure *= self._profiles.limiter_core_mask
+        except AttributeError as e:
+            print(e)
+            warnings.warn(
+                "The core mask is not in place. You need to solve for the equilibrium first!"
+            )
+            raise e
+
+        # calculate the poloidal beta by integrating pressure in 2D
+        return (
+            ((8.0 * pi) / mu0)
+            * romb(romb(pressure))
+            * self.dR
+            * self.dZ
+            / (self.plasmaCurrent() ** 2)
+        )
+        
+    def poloidalBeta2(self):
+        """
+        Calculates an (alternative) poloidal beta from the following definition:
+        
+            betap = 2 * mu0 * integral(p) dV / integral(Bpol^2) dV,
+        
+        where:
+         - mu0 = magnetic permeability in vacuum.
+         - p = plasma pressure (at each (R,Z)).
+         - Bpol(R,Z) = poloidal magnetic field (at each (R,Z)).
+         - dV = volume element.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float
+            Returns the poloidal beta value.
+        """
+    
+        # extract Bpol squared
+        B_pol_2 = self.Bpol(self.R, self.Z)**2
+
+        # volume elements
+        dV = 2.0 * np.pi * self.R * self.dR * self.dZ
+
+        # plasma pressure
+        pressure = self.pressure(self.psiNRZ(self.R, self.Z))
+
+        # mask with the core plasma 
+        try:
+            dV *= self._profiles.limiter_core_mask
+        except AttributeError as e:
+            print(e)
+            warnings.warn(
+                "The core mask is not in place. You need to solve for the equilibrium first!"
+            )
+            raise e
+
+        pressure_integral = romb(romb(pressure * dV))
+        field_integral_pol = romb(romb(B_pol_2 * dV))
+        
+        return 2 * mu0 * pressure_integral / field_integral_pol
+
+    def toroidalBeta(self):
+        """
+        Calculates a toroidal beta from the following definition:
+        
+            betat = 2 * mu0 * integral(p) dV / integral(Btor^2) dV,
+        
+        where:
+         - mu0 = magnetic permeability in vacuum.
+         - p = plasma pressure (at each (R,Z)).
+         - Btor(R,Z) = toroidal magnetic field (at each (R,Z)).
+         - dV = volume element.
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float
+            Returns the toroidal beta value.
+        """
+
+        # extract Btor squared
+        B_tor_2 = self.Btor(self.R, self.Z) ** 2
+
+        # volume elements
+        dV = 2.0 * np.pi * self.R * self.dR * self.dZ
+
+        # plasma pressure
+        pressure = self.pressure(self.psiNRZ(self.R, self.Z))
+
+        # mask with the core plasma 
+        try:
+            dV *= self._profiles.limiter_core_mask
+        except AttributeError as e:
+            print(e)
+            warnings.warn(
+                "The core mask is not in place. You need to solve for the equilibrium first!"
+            )
+            raise e
+
+        pressure_integral = romb(romb(pressure * dV))
+
+        # correct for errors in Btor and core masking
+        np.nan_to_num(B_tor_2, copy=False)
+
+        field_integral_tor = romb(romb(B_tor_2 * dV))
+        
+        return 2 * mu0 * pressure_integral / field_integral_tor
+
+    def normalised_total_Beta(self):
+        """
+        Calculates the total beta from the following definition:
+        
+            normalised_total_Beta = ( (1 / poloidalBeta2) + (1/toroidalBeta) )^(-1).
+
+        Parameters
+        ----------
+
+        Returns
+        -------
+        float
+            Returns the normalised total beta value.
+            
+        """
+        
+        return 1.0 / ((1.0 / self.poloidalBeta2()) + (1.0 / self.toroidalBeta()))
+
+    def strikepoints(self):
+        """
+        This function can be used to find the strikepoints of an equilibrium (i.e
+        the points at which the psi_boundary contour intersect the wall. 
+        
+        Parameters
+        ----------
+
+        Returns
+        -------
+        np.array
+            Returns an array of the (R,Z) strikepoints.
+            
+        """
+
+        # find contour object for psi_boundary
+        if self._profiles.flag_limiter:
+            cs = plt.contour(
+                self.R, self.Z, self.psi(), levels=[self._profiles.psi_bndry]
+            )
+        else:
+            cs = plt.contour(
+                self.R, self.Z, self.psi(), levels=[self._profiles.xpt[0][2]]
+            )
+        plt.close()  # this isn't the most elegant but we don't need the plot itself
+
+        # for each item in the contour object there's a list of points in (r,z) (i.e. a line)
+        psi_boundary_lines = []
+        for i, item in enumerate(cs.allsegs[0]):
+            psi_boundary_lines.append(item)
+
+        # use the shapely package to find where each psi_boundary_line intersects the wall (or not)
+        strikes = []
+        wall = np.array([self.tokamak.wall.R, self.tokamak.wall.Z]).T
+        curve1 = sh.LineString(wall)
+        for j, line in enumerate(psi_boundary_lines):
+            curve2 = sh.LineString(line)
+
+            # find the intersection points
+            intersection = curve2.intersection(curve1)
+
+            # extract intersection points
+            if intersection.geom_type == "Point":
+                strikes.append(np.squeeze(np.array(intersection.xy).T))
+            elif intersection.geom_type == "MultiPoint":
+                strikes.append(
+                    np.squeeze(
+                        np.array([geom.xy for geom in intersection.geoms])
+                    )
+                )
+
+        # check how many strikepoints
+        if len(strikes) == 0:
+            out = None
+        else:
+            out = np.concatenate(strikes, axis=0)
+
+        return out
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
     def solve(self, profiles, Jtor=None, psi=None, psi_bndry=None):
         """
@@ -542,432 +2028,6 @@ class Equilibrium:
         from .plotting import plotEquilibrium
 
         return plotEquilibrium(self, axis=axis, show=show, oxpoints=oxpoints)
-
-    def getForces(self):
-        """
-        Calculate forces on the coils
-
-        Returns a dictionary of coil label -> force
-        """
-        return self.tokamak.getForces(self)
-
-    def printForces(self):
-        """
-        Prints a table of forces on coils
-        """
-        print("Forces on coils")
-
-        def print_forces(forces, prefix=""):
-            for label, force in forces.items():
-                if isinstance(force, dict):
-                    print(prefix + label + " (circuit)")
-                    print_forces(force, prefix=prefix + "  ")
-                else:
-                    print(
-                        prefix
-                        + label
-                        + " : R = {0:.2f} kN , Z = {1:.2f} kN".format(
-                            force[0] * 1e-3, force[1] * 1e-3
-                        )
-                    )
-
-        print_forces(self.getForces())
-
-    def innerOuterSeparatrix(
-        self, Z: float = 0.0, recalculate_equilibrium: bool = True
-    ):
-        """
-        Locate R co ordinates of separatrix at both inboard and outboard
-        poloidal midplane (Z = 0).
-
-        If the equilibrium has recently been solved, you can set
-        recalculate_equilibrium to False to avoid recalculating it.
-
-        Parameters
-        ----------
-        Z : float, optional
-            The Z value at which to find the separatrix. Defaults to
-            0.0.
-        recalculate_equilibrium : bool, optional
-            Whether or not to recalculate the equilibrium. Defaults to
-            True.
-
-        Returns
-        -------
-        R_sep_in : float
-            The inner separatrix major radius.
-        R_sep_out : float
-            The outer separatrix major radius.
-        """
-        # Find the closest index to requested Z
-        Zindex = np.argmin(abs(self.Z[0, :] - Z))
-
-        # Normalise psi at this Z index
-        psinorm = (self.psi()[:, Zindex] - self.psi_axis) / (
-            self.psi_bndry - self.psi_axis
-        )
-
-        if recalculate_equilibrium:
-            Rindex_axis = np.argmin(abs(self.R[:, 0] - self.Rmagnetic()))
-        else:
-            try:
-                Rindex_axis = Rindex_axis = np.argmin(
-                    abs(eq.R[:, 0] - self._profiles.opt[0][0])
-                )
-            except AttributeError as e:
-                print(e)
-                warnings.warn(
-                    "The equilibrium object does not seem to have been updated. "
-                    + "You can pass recalculate_equilibrium=True to find the magnetic axis."
-                )
-                raise e
-
-        # Start from the magnetic axis
-        if Rindex_axis is None:
-            Rindex_axis = np.argmin(abs(self.R[:, 0] - self.Rmagnetic()))
-
-        # Inner separatrix
-        # Get the maximum index where psi > 1 in the R index range from 0 to Rindex_axis
-        outside_inds = np.argwhere(psinorm[:Rindex_axis] > 1.0)
-
-        if outside_inds.size == 0:
-            R_sep_in = self.Rmin
-        else:
-            Rindex_inner = np.amax(outside_inds)
-
-            # Separatrix should now be between Rindex_inner and Rindex_inner+1
-            # Linear interpolation
-            R_sep_in = (
-                self.R[Rindex_inner, Zindex]
-                * (1.0 - psinorm[Rindex_inner + 1])
-                + self.R[Rindex_inner + 1, Zindex]
-                * (psinorm[Rindex_inner] - 1.0)
-            ) / (psinorm[Rindex_inner] - psinorm[Rindex_inner + 1])
-
-        # Outer separatrix
-        # Find the minimum index where psi > 1
-        outside_inds = np.argwhere(psinorm[Rindex_axis:] > 1.0)
-
-        if outside_inds.size == 0:
-            R_sep_out = self.Rmax
-        else:
-            Rindex_outer = np.amin(outside_inds) + Rindex_axis
-
-            # Separatrix should now be between Rindex_outer-1 and Rindex_outer
-            R_sep_out = (
-                self.R[Rindex_outer, Zindex]
-                * (1.0 - psinorm[Rindex_outer - 1])
-                + self.R[Rindex_outer - 1, Zindex]
-                * (psinorm[Rindex_outer] - 1.0)
-            ) / (psinorm[Rindex_outer] - psinorm[Rindex_outer - 1])
-
-        return R_sep_in, R_sep_out
-
-    def intersectsWall(self):
-        """Assess whether or not the core plasma touches the vessel
-        walls. Returns True if it does intersect.
-        """
-        separatrix = self.separatrix()  # Array [:,2]
-        wall = self.tokamak.wall  # Wall object with R and Z members (lists)
-
-        return polygons.intersect(
-            separatrix[:, 0], separatrix[:, 1], wall.R, wall.Z
-        )
-
-    def magneticAxis(self):
-        """Returns the location of the magnetic axis as a list [R,Z,psi]"""
-        opt, xpt = critical.find_critical(self.R, self.Z, self.psi())
-        return opt[0]
-
-    def Rmagnetic(self):
-        """The major radius R of magnetic major radius"""
-        return self.magneticAxis()[0]
-
-    def geometricAxis(self, npoints=300):
-        """Locates geometric axis, returning [R,Z]. Calculated as the centre
-        of a large number of points on the separatrix equally
-        distributed in angle from the magnetic axis.
-        """
-        separatrix = self.separatrix(ntheta=npoints)  # Array [:,2]
-        return np.mean(separatrix, axis=0)
-
-    def Rgeometric(self, npoints=300):
-        """Locates major radius R of the geometric major radius. Calculated
-        as the centre of a large number of points on the separatrix
-        equally distributed in angle from the magnetic axis.
-        """
-        return self.geometricAxis(npoints=npoints)[0]
-
-    def minorRadius(self, npoints=300):
-        """Calculates minor radius of plasma as the average distance from the
-        geometric major radius to a number of points along the
-        separatrix
-        """
-        separatrix = self.separatrix(ntheta=npoints)  # [:,2]
-        axis = np.mean(separatrix, axis=0)  # Geometric axis [R,Z]
-
-        # Calculate average distance from the geometric axis
-        return np.mean(
-            np.sqrt(
-                (separatrix[:, 0] - axis[0]) ** 2
-                + (separatrix[:, 1] - axis[1]) ** 2  # dR^2
-            )
-        )  # dZ^2
-
-    def geometricElongation(self, npoints=300):
-        """Calculates the elongation of a plasma using the range of R and Z of
-        the separatrix
-
-        """
-        separatrix = self.separatrix(ntheta=npoints)  # [:,2]
-        # Range in Z / range in R
-        return (max(separatrix[:, 1]) - min(separatrix[:, 1])) / (
-            max(separatrix[:, 0]) - min(separatrix[:, 0])
-        )
-
-    def aspectRatio(self, npoints=300):
-        """Calculates the plasma aspect ratio"""
-        return self.Rgeometric(npoints=npoints) / self.minorRadius(
-            npoints=npoints
-        )
-
-    def effectiveElongation(self, npoints=300):
-        """Calculates plasma effective elongation using the plasma volume"""
-        return self.plasmaVolume() / (
-            2.0
-            * np.pi
-            * self.Rgeometric(npoints=npoints)
-            * np.pi
-            * self.minorRadius(npoints=npoints) ** 2
-        )
-
-    def internalInductance1(self, npoints=300):
-        """Calculates li1 plasma internal inductance"""
-
-        R = self.R
-        Z = self.Z
-        # Produce array of Bpol^2 in (R,Z)
-        B_polvals_2 = self.Bz(R, Z) ** 2 + self.Br(R, Z) ** 2
-
-        dR = R[1, 0] - R[0, 0]
-        dZ = Z[0, 1] - Z[0, 0]
-        dV = 2.0 * np.pi * R * dR * dZ
-
-        try:
-            dV *= self._profiles.limiter_core_mask
-        except AttributeError as e:
-            print(e)
-            warnings.warn(
-                "The core mask is not in place. You need to solve for the equilibrium first!"
-            )
-            raise e
-
-        Ip = self.plasmaCurrent()
-        R_geo = self.Rgeometric(npoints=npoints)
-        elon = self.geometricElongation(npoints=npoints)
-        effective_elon = self.effectiveElongation(npoints=npoints)
-
-        integral = romb(romb(B_polvals_2 * dV))
-        return ((2 * integral) / ((mu0 * Ip) ** 2 * R_geo)) * (
-            (1 + elon * elon) / (2.0 * effective_elon)
-        )
-
-    def internalInductance2(self):
-        """Calculates li2 plasma internal inductance"""
-
-        R = self.R
-        Z = self.Z
-        # Produce array of Bpol in (R,Z)
-        B_polvals_2 = self.Br(R, Z) ** 2 + self.Bz(R, Z) ** 2
-
-        dR = R[1, 0] - R[0, 0]
-        dZ = Z[0, 1] - Z[0, 0]
-        dV = 2.0 * np.pi * R * dR * dZ
-
-        try:
-            dV *= self._profiles.limiter_core_mask
-        except AttributeError as e:
-            print(e)
-            warnings.warn(
-                "The core mask is not in place. You need to solve for the equilibrium first!"
-            )
-            raise e
-
-        Ip = self.plasmaCurrent()
-        R_mag = self.Rmagnetic()
-
-        integral = romb(romb(B_polvals_2 * dV))
-        return 2 * integral / ((mu0 * Ip) ** 2 * R_mag)
-
-    def internalInductance3(self, npoints=300):
-        """Calculates li3 plasma internal inductance"""
-
-        R = self.R
-        Z = self.Z
-        # Produce array of Bpol in (R,Z)
-        B_polvals_2 = self.Br(R, Z) ** 2 + self.Bz(R, Z) ** 2
-
-        dR = R[1, 0] - R[0, 0]
-        dZ = Z[0, 1] - Z[0, 0]
-        dV = 2.0 * np.pi * R * dR * dZ
-
-        try:
-            dV *= self._profiles.limiter_core_mask
-        except AttributeError as e:
-            print(e)
-            warnings.warn(
-                "The core mask is not in place. You need to solve for the equilibrium first!"
-            )
-            raise e
-
-        Ip = self.plasmaCurrent()
-        R_geo = self.Rgeometric(npoints=npoints)
-
-        integral = romb(romb(B_polvals_2 * dV))
-        return 2 * integral / ((mu0 * Ip) ** 2 * R_geo)
-
-    def poloidalBeta2(self):
-        """Calculate plasma poloidal beta by integrating the thermal pressure
-        and poloidal magnetic field pressure over the plasma volume.
-
-        """
-
-        R = self.R
-        Z = self.Z
-
-        # Produce array of Bpol in (R,Z)
-        B_polvals_2 = self.Br(R, Z) ** 2 + self.Bz(R, Z) ** 2
-
-        dR = R[1, 0] - R[0, 0]
-        dZ = Z[0, 1] - Z[0, 0]
-        dV = 2.0 * np.pi * R * dR * dZ
-
-        # Normalised psi
-        psi_norm = (self.psi() - self.psi_axis) / (
-            self.psi_bndry - self.psi_axis
-        )
-
-        # Plasma pressure
-        pressure = self.pressure(psi_norm)
-
-        try:
-            dV *= self._profiles.limiter_core_mask
-        except AttributeError as e:
-            print(e)
-            warnings.warn(
-                "The core mask is not in place. You need to solve for the equilibrium first!"
-            )
-            raise e
-
-        pressure_integral = romb(romb(pressure * dV))
-        field_integral_pol = romb(romb(B_polvals_2 * dV))
-        return 2 * mu0 * pressure_integral / field_integral_pol
-
-    def toroidalBeta(self):
-        """Calculate plasma toroidal beta by integrating the thermal pressure
-        and toroidal magnetic field pressure over the plasma volume.
-
-        """
-
-        R = self.R
-        Z = self.Z
-
-        # Produce array of Btor in (R,Z)
-        B_torvals_2 = self.Btor(R, Z) ** 2
-
-        dR = R[1, 0] - R[0, 0]
-        dZ = Z[0, 1] - Z[0, 0]
-        dV = 2.0 * np.pi * R * dR * dZ
-
-        # Normalised psi
-        psi_norm = (self.psi() - self.psi_axis) / (
-            self.psi_bndry - self.psi_axis
-        )
-
-        # Plasma pressure
-        pressure = self.pressure(psi_norm)
-
-        try:
-            dV *= self._profiles.limiter_core_mask
-        except AttributeError as e:
-            print(e)
-            warnings.warn(
-                "The core mask is not in place. You need to solve for the equilibrium first!"
-            )
-            raise e
-
-        pressure_integral = romb(romb(pressure * dV))
-
-        # Correct for errors in Btor and core masking
-        np.nan_to_num(B_torvals_2, copy=False)
-
-        field_integral_tor = romb(romb(B_torvals_2 * dV))
-        return 2 * mu0 * pressure_integral / field_integral_tor
-
-    def totalBeta(self):
-        """Calculate plasma total beta"""
-        return 1.0 / (
-            (1.0 / self.poloidalBeta2()) + (1.0 / self.toroidalBeta())
-        )
-
-    def strikepoints(self):
-        """
-            This function can be used to find the strikepoints of an equilibrium
-            using the:
-
-            - R and Z grids (2D)
-            - psi_total (2D) (i.e. the poloidal flux map)
-            - psi_boundary (single value)
-            - wall coordinates (N x 2)
-
-        It should find the intersection between any points on the psi_boundary contour
-        of psi_total and the wall of the tokamak.
-        """
-
-        # find contour object for psi_boundary
-        if self._profiles.flag_limiter:
-            cs = plt.contour(
-                self.R, self.Z, self.psi(), levels=[self._profiles.psi_bndry]
-            )
-        else:
-            cs = plt.contour(
-                self.R, self.Z, self.psi(), levels=[self._profiles.xpt[0][2]]
-            )
-        plt.close()  # this isn't the most elegant but we don't need the plot itself
-
-        # for each item in the contour object there's a list of points in (r,z) (i.e. a line)
-        psi_boundary_lines = []
-        for i, item in enumerate(cs.allsegs[0]):
-            psi_boundary_lines.append(item)
-
-        # use the shapely package to find where each psi_boundary_line intersects the wall (or not)
-        strikes = []
-        wall = np.array([self.tokamak.wall.R, self.tokamak.wall.Z]).T
-        curve1 = sh.LineString(wall)
-        for j, line in enumerate(psi_boundary_lines):
-            curve2 = sh.LineString(line)
-
-            # find the intersection points
-            intersection = curve2.intersection(curve1)
-
-            # extract intersection points
-            if intersection.geom_type == "Point":
-                strikes.append(np.squeeze(np.array(intersection.xy).T))
-            elif intersection.geom_type == "MultiPoint":
-                strikes.append(
-                    np.squeeze(
-                        np.array([geom.xy for geom in intersection.geoms])
-                    )
-                )
-
-        # check how many strikepoints
-        if len(strikes) == 0:
-            out = None
-        else:
-            out = np.concatenate(strikes, axis=0)
-
-        return out
-
 
 def refine(eq, nx=None, ny=None):
     """
@@ -1097,6 +2157,29 @@ def newDomain(
     result.solve(profiles)
 
     return result
+
+def ellipse_points(R0, Z0, A, B, N=360):
+    """This function generates the (R,Z) points of an ellipse:
+    (x/A)**2 + (y/B)**2 = 1.
+
+    Parameters
+    ----------
+    R0, Z0, A, B: floats
+        Centre of ellipse (R0,Z0) and the ellipticity parameters A and B.
+    N: int
+        Number of points to generate on the ellipse.
+
+    Returns
+    -------
+    np.ndarray
+        (N x 2) numpy array of points on the ellipse.
+    """
+
+    theta = np.linspace(0, 2 * np.pi, N)
+    R = R0 + A * np.cos(theta)
+    Z = Z0 + B * np.sin(theta)
+
+    return np.column_stack((R, Z))
 
 
 if __name__ == "__main__":

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -93,12 +93,18 @@ class Equilibrium:
         self.tokamak = tokamak
 
         # assign bounds of computational domain
+        if Rmin > Rmax:
+            raise ValueError("Rmin must be smaller than Rmax.")
+        if Zmin > Zmax:
+            raise ValueError("Zmin must be smaller than Zmax.")
         self.Rmin = Rmin
         self.Rmax = Rmax
         self.Zmin = Zmin
         self.Zmax = Zmax
 
         # assign number of grid points
+        if nx < 0 or ny < 0:
+            raise ValueError("nx and ny must be integers greater than zero.")
         self.nx = nx
         self.ny = ny
 
@@ -119,6 +125,9 @@ class Equilibrium:
             # Starting guess for psi
             psi = self.create_psi_plasma_default()
             self.gpars = np.array([0.5, 0.5, 0, 2])
+
+        if psi.shape != (nx, ny):
+            raise ValueError("Shape of psi must match grid size (nx, ny).")
         self.plasma_psi = psi
 
         # generate Greens function mappings (used

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -1851,10 +1851,10 @@ class Equilibrium:
         )
 
     def strikepoints(
-        self, 
-        quadrant = "all", 
-        loc = None,
-        ):
+        self,
+        quadrant="all",
+        loc=None,
+    ):
         """
         This function can be used to find the strikepoints of an equilibrium (i.e
         the points at which the psi_boundary contour intersect the wall.
@@ -1863,11 +1863,11 @@ class Equilibrium:
         ----------
         quadrant: str
             Which strikepoints to return to the user, options are "all" (returns all points) or
-            one of "lower left", "lower right", "upper left", or "upper right" quadrants (which 
-            returns point(s) in quadrant of poloidal plane with centre given by 'loc' (R,Z) pair). 
+            one of "lower left", "lower right", "upper left", or "upper right" quadrants (which
+            returns point(s) in quadrant of poloidal plane with centre given by 'loc' (R,Z) pair).
         loc: tuple
-            (R,Z) point at which to centre the quadrants choice [m]. 
-            
+            (R,Z) point at which to centre the quadrants choice [m].
+
         Returns
         -------
         np.array
@@ -1916,33 +1916,47 @@ class Equilibrium:
             return None
         else:
             all_strikes = np.concatenate(strikes, axis=0)
-            
-        
+
         # which strikepoint(s) to return
         if quadrant == "all":
             return all_strikes
         else:
             if loc == None:
-                raise ValueError(f"Need to define quadrant centre point in 'loc' (R,Z).")
-            else:                
+                raise ValueError(
+                    f"Need to define quadrant centre point in 'loc' (R,Z)."
+                )
+            else:
                 if quadrant == "lower left":
-                    ind = np.where((all_strikes[:,0] < loc[0]) & (all_strikes[:,1] < loc[1]))[0]
+                    ind = np.where(
+                        (all_strikes[:, 0] < loc[0])
+                        & (all_strikes[:, 1] < loc[1])
+                    )[0]
                 elif quadrant == "lower right":
-                    ind = np.where((all_strikes[:,0] > loc[0]) & (all_strikes[:,1] < loc[1]))[0]
+                    ind = np.where(
+                        (all_strikes[:, 0] > loc[0])
+                        & (all_strikes[:, 1] < loc[1])
+                    )[0]
                 elif quadrant == "upper left":
-                    ind = np.where((all_strikes[:,0] < loc[0]) & (all_strikes[:,1] > loc[1]))[0]
+                    ind = np.where(
+                        (all_strikes[:, 0] < loc[0])
+                        & (all_strikes[:, 1] > loc[1])
+                    )[0]
                 elif quadrant == "upper right":
-                    ind = np.where((all_strikes[:,0] > loc[0]) & (all_strikes[:,1] > loc[1]))[0]
+                    ind = np.where(
+                        (all_strikes[:, 0] > loc[0])
+                        & (all_strikes[:, 1] > loc[1])
+                    )[0]
                 else:
-                    raise ValueError(f"Unexpected quadrant: {quadrant}. Choose from 'all', "
-                        f"'lower left', 'lower right', 'upper left', or 'upper right'.")
-
+                    raise ValueError(
+                        f"Unexpected quadrant: {quadrant}. Choose from 'all', "
+                        f"'lower left', 'lower right', 'upper left', or 'upper right'."
+                    )
 
         # return if quadrant value required
-        if len(ind) == 0:       
+        if len(ind) == 0:
             return np.full(2, None)
         else:
-            return np.array([all_strikes[:,0][ind], all_strikes[:,1][ind]]).T
+            return np.array([all_strikes[:, 0][ind], all_strikes[:, 1][ind]]).T
 
     def solve(self, profiles, Jtor=None, psi=None, psi_bndry=None):
         """

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -1956,7 +1956,9 @@ class Equilibrium:
         if len(ind) == 0:
             return np.full(2, None)
         else:
-            return np.array([all_strikes[:, 0][ind], all_strikes[:, 1][ind]]).T.squeeze()
+            return np.array(
+                [all_strikes[:, 0][ind], all_strikes[:, 1][ind]]
+            ).T.squeeze()
 
     def solve(self, profiles, Jtor=None, psi=None, psi_bndry=None):
         """

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -1956,7 +1956,7 @@ class Equilibrium:
         if len(ind) == 0:
             return np.full(2, None)
         else:
-            return np.array([all_strikes[:, 0][ind], all_strikes[:, 1][ind]]).T
+            return np.array([all_strikes[:, 0][ind], all_strikes[:, 1][ind]]).T.squeeze()
 
     def solve(self, profiles, Jtor=None, psi=None, psi_bndry=None):
         """

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -154,7 +154,7 @@ class Equilibrium:
         self._solver = multigrid.createVcycle(
             nx, ny, generator, nlevels=1, ncycle=1, niter=2, direct=True
         )
-        
+
         # separatrix data not yet calculated
         self._separatrix_data_flag = False
 
@@ -868,14 +868,13 @@ class Equilibrium:
         float
             Area of the last closed flux surface (plasma boundary) [m^2].
         """
-        
+
         # check if metrics are already calculated
         if self._separatrix_data_flag is False:
-            self._separatrix_metrics() # call function
-            self._separatrix_data_flag = True # update flag
+            self._separatrix_metrics()  # call function
+            self._separatrix_data_flag = True  # update flag
 
         return self._sep_area
-
 
     def separatrix_length(self):
         """
@@ -892,8 +891,8 @@ class Equilibrium:
 
         # check if metrics are already calculated
         if self._separatrix_data_flag is False:
-            self._separatrix_metrics() # call function
-            self._separatrix_data_flag = True # update flag
+            self._separatrix_metrics()  # call function
+            self._separatrix_data_flag = True  # update flag
 
         return self._sep_length
 
@@ -1099,7 +1098,9 @@ class Equilibrium:
 
         # find closest O-point to the geometric axis
         geom_axis = self.geometricAxis()[0:2]
-        o_point_ind = np.argmin(np.sum((opts[:,0:2] - geom_axis) ** 2, axis=1))
+        o_point_ind = np.argmin(
+            np.sum((opts[:, 0:2] - geom_axis) ** 2, axis=1)
+        )
 
         return opts[o_point_ind, :]
 
@@ -1149,10 +1150,15 @@ class Equilibrium:
 
         # check if metrics are already calculated
         if self._separatrix_data_flag is False:
-            self._separatrix_metrics() # call function
-            self._separatrix_data_flag = True # update flag
-    
-        return np.array([(self._sep_Rmax + self._sep_Rmin) / 2, (self._sep_Zmax + self._sep_Zmin) / 2])
+            self._separatrix_metrics()  # call function
+            self._separatrix_data_flag = True  # update flag
+
+        return np.array(
+            [
+                (self._sep_Rmax + self._sep_Rmin) / 2,
+                (self._sep_Zmax + self._sep_Zmin) / 2,
+            ]
+        )
 
     def Rgeometric(self):
         """
@@ -1199,9 +1205,9 @@ class Equilibrium:
 
         # check if metrics are already calculated
         if self._separatrix_data_flag is False:
-            self._separatrix_metrics() # call function
-            self._separatrix_data_flag = True # update flag
-    
+            self._separatrix_metrics()  # call function
+            self._separatrix_data_flag = True  # update flag
+
         return (self._sep_Rmax - self._sep_Rmin) / 2
 
     def aspectRatio(self):
@@ -1219,10 +1225,12 @@ class Equilibrium:
 
         # check if metrics are already calculated
         if self._separatrix_data_flag is False:
-            self._separatrix_metrics() # call function
-            self._separatrix_data_flag = True # update flag
-    
-        return (self._sep_Rmax + self._sep_Rmin) / (self._sep_Rmax - self._sep_Rmin)
+            self._separatrix_metrics()  # call function
+            self._separatrix_data_flag = True  # update flag
+
+        return (self._sep_Rmax + self._sep_Rmin) / (
+            self._sep_Rmax - self._sep_Rmin
+        )
 
     def geometricElongation(self):
         """
@@ -1236,13 +1244,15 @@ class Equilibrium:
         float
             Geometric elongation of the plasma.
         """
-        
+
         # check if metrics are already calculated
         if self._separatrix_data_flag is False:
-            self._separatrix_metrics() # call function
-            self._separatrix_data_flag = True # update flag
-    
-        return (self._sep_Zmax - self._sep_Zmin) / (self._sep_Rmax - self._sep_Rmin)
+            self._separatrix_metrics()  # call function
+            self._separatrix_data_flag = True  # update flag
+
+        return (self._sep_Zmax - self._sep_Zmin) / (
+            self._sep_Rmax - self._sep_Rmin
+        )
 
     def geometricElongation_upper(self):
         """
@@ -1259,10 +1269,14 @@ class Equilibrium:
 
         # check if metrics are already calculated
         if self._separatrix_data_flag is False:
-            self._separatrix_metrics() # call function
-            self._separatrix_data_flag = True # update flag
+            self._separatrix_metrics()  # call function
+            self._separatrix_data_flag = True  # update flag
 
-        return 2 * (self._sep_Zmax - self._sep_ZRmax) / (self._sep_Rmax - self._sep_Rmin)
+        return (
+            2
+            * (self._sep_Zmax - self._sep_ZRmax)
+            / (self._sep_Rmax - self._sep_Rmin)
+        )
 
     def geometricElongation_lower(self):
         """
@@ -1279,10 +1293,14 @@ class Equilibrium:
 
         # check if metrics are already calculated
         if self._separatrix_data_flag is False:
-            self._separatrix_metrics() # call function
-            self._separatrix_data_flag = True # update flag
-    
-        return 2 * (self._sep_ZRmax - self._sep_Zmin) / (self._sep_Rmax - self._sep_Rmin)
+            self._separatrix_metrics()  # call function
+            self._separatrix_data_flag = True  # update flag
+
+        return (
+            2
+            * (self._sep_ZRmax - self._sep_Zmin)
+            / (self._sep_Rmax - self._sep_Rmin)
+        )
 
     def effectiveElongation(self):
         """
@@ -1299,9 +1317,8 @@ class Equilibrium:
 
         # check if metrics are already calculated
         if self._separatrix_data_flag is False:
-            self._separatrix_metrics() # call function
-            self._separatrix_data_flag = True # update flag
-    
+            self._separatrix_metrics()  # call function
+            self._separatrix_data_flag = True  # update flag
 
         R_geom = (self._sep_Rmax + self._sep_Rmin) / 2
         R_minor = (self._sep_Rmax - self._sep_Rmin) / 2
@@ -1344,8 +1361,8 @@ class Equilibrium:
 
         # check if metrics are already calculated
         if self._separatrix_data_flag is False:
-            self._separatrix_metrics() # call function
-            self._separatrix_data_flag = True # update flag
+            self._separatrix_metrics()  # call function
+            self._separatrix_data_flag = True  # update flag
 
         R_geom = (self._sep_Rmax + self._sep_Rmin) / 2
         R_minor = (self._sep_Rmax - self._sep_Rmin) / 2
@@ -1367,8 +1384,8 @@ class Equilibrium:
 
         # check if metrics are already calculated
         if self._separatrix_data_flag is False:
-            self._separatrix_metrics() # call function
-            self._separatrix_data_flag = True # update flag
+            self._separatrix_metrics()  # call function
+            self._separatrix_data_flag = True  # update flag
 
         R_geom = (self._sep_Rmax + self._sep_Rmin) / 2
         R_minor = (self._sep_Rmax - self._sep_Rmin) / 2
@@ -1390,9 +1407,9 @@ class Equilibrium:
 
         # check if metrics are already calculated
         if self._separatrix_data_flag is False:
-            self._separatrix_metrics() # call function
-            self._separatrix_data_flag = True # update flag
-    
+            self._separatrix_metrics()  # call function
+            self._separatrix_data_flag = True  # update flag
+
         R_geom = (self._sep_Rmax + self._sep_Rmin) / 2
         R_minor = (self._sep_Rmax - self._sep_Rmin) / 2
 
@@ -1423,31 +1440,71 @@ class Equilibrium:
 
         # check if metrics are already calculated
         if self._separatrix_data_flag is False:
-            self._separatrix_metrics() # call function
-            self._separatrix_data_flag = True # update flag
+            self._separatrix_metrics()  # call function
+            self._separatrix_data_flag = True  # update flag
 
         # create shapely object for plasma core
         plasma_boundary = sh.Polygon(self.separatrix())
 
         # same for "ideal" ellipses in each quadrant
         uo_ellipse = sh.Polygon(
-            ellipse_points(R0=self._sep_RZmax, Z0=self._sep_ZRmax, A=self._sep_Rmax - self._sep_RZmax, B=self._sep_Zmax - self._sep_ZRmax)
+            ellipse_points(
+                R0=self._sep_RZmax,
+                Z0=self._sep_ZRmax,
+                A=self._sep_Rmax - self._sep_RZmax,
+                B=self._sep_Zmax - self._sep_ZRmax,
+            )
         )
         ui_ellipse = sh.Polygon(
-            ellipse_points(R0=self._sep_RZmax, Z0=self._sep_ZRmax, A=self._sep_RZmax - self._sep_Rmin, B=self._sep_Zmax - self._sep_ZRmax)
+            ellipse_points(
+                R0=self._sep_RZmax,
+                Z0=self._sep_ZRmax,
+                A=self._sep_RZmax - self._sep_Rmin,
+                B=self._sep_Zmax - self._sep_ZRmax,
+            )
         )
         lo_ellipse = sh.Polygon(
-            ellipse_points(R0=self._sep_RZmin, Z0=self._sep_ZRmax, A=self._sep_Rmax - self._sep_RZmin, B=self._sep_ZRmax - self._sep_Zmin)
+            ellipse_points(
+                R0=self._sep_RZmin,
+                Z0=self._sep_ZRmax,
+                A=self._sep_Rmax - self._sep_RZmin,
+                B=self._sep_ZRmax - self._sep_Zmin,
+            )
         )
         li_ellipse = sh.Polygon(
-            ellipse_points(R0=self._sep_RZmin, Z0=self._sep_ZRmax, A=self._sep_RZmin - self._sep_Rmin, B=self._sep_ZRmax - self._sep_Zmin)
+            ellipse_points(
+                R0=self._sep_RZmin,
+                Z0=self._sep_ZRmax,
+                A=self._sep_RZmin - self._sep_Rmin,
+                B=self._sep_ZRmax - self._sep_Zmin,
+            )
         )
 
         # bounding box diagonals
-        uo_diag = sh.LineString([[self._sep_RZmax, self._sep_ZRmax], [self._sep_Rmax, self._sep_Zmax]])
-        ui_diag = sh.LineString([[self._sep_RZmax, self._sep_ZRmax], [self._sep_Rmin, self._sep_Zmax]])
-        lo_diag = sh.LineString([[self._sep_RZmin, self._sep_ZRmax], [self._sep_Rmax, self._sep_Zmin]])
-        li_diag = sh.LineString([[self._sep_RZmin, self._sep_ZRmax], [self._sep_Rmin, self._sep_Zmin]])
+        uo_diag = sh.LineString(
+            [
+                [self._sep_RZmax, self._sep_ZRmax],
+                [self._sep_Rmax, self._sep_Zmax],
+            ]
+        )
+        ui_diag = sh.LineString(
+            [
+                [self._sep_RZmax, self._sep_ZRmax],
+                [self._sep_Rmin, self._sep_Zmax],
+            ]
+        )
+        lo_diag = sh.LineString(
+            [
+                [self._sep_RZmin, self._sep_ZRmax],
+                [self._sep_Rmax, self._sep_Zmin],
+            ]
+        )
+        li_diag = sh.LineString(
+            [
+                [self._sep_RZmin, self._sep_ZRmax],
+                [self._sep_Rmin, self._sep_Zmin],
+            ]
+        )
 
         # find intersecting line lengths
         uo_diag_core = uo_diag.intersection(plasma_boundary).length
@@ -2078,7 +2135,7 @@ class Equilibrium:
         Returns
         -------
         None
-            Modifies eq object in place. 
+            Modifies eq object in place.
         """
 
         # calculate core separatrix
@@ -2107,7 +2164,7 @@ class Equilibrium:
         area = plasma_polygon.area
         length = plasma_polygon.length
 
-        self._sep_Rmin =  Rmin
+        self._sep_Rmin = Rmin
         self._sep_Rmax = Rmax
         self._sep_Zmin = Zmin
         self._sep_Zmax = Zmax
@@ -2117,7 +2174,8 @@ class Equilibrium:
         self._sep_RZmax = RZmax
         self._sep_area = area
         self._sep_length = length
-                
+
+
 def ellipse_points(R0, Z0, A, B, N=360):
     """
     This function generates the (R,Z) points of an ellipse:
@@ -2141,6 +2199,7 @@ def ellipse_points(R0, Z0, A, B, N=360):
     Z = Z0 + B * np.sin(theta)
 
     return np.column_stack((R, Z))
+
 
 if __name__ == "__main__":
 

--- a/freegs4e/gradshafranov.py
+++ b/freegs4e/gradshafranov.py
@@ -1,5 +1,6 @@
 """
-Grad-Shafranov equation
+Contains various classes and functions related to the elliptic operator 
+of the Grad-Shafranov equation. 
 
 Copyright 2016 Ben Dudson, University of York. Email: benjamin.dudson@york.ac.uk
 
@@ -23,54 +24,74 @@ along with FreeGS4E.  If not, see <http://www.gnu.org/licenses/>.
 from numpy import clip, pi, sqrt, zeros
 from scipy.sparse import eye, lil_matrix
 
-# Elliptic integrals of first and second kind (K and E)
+# elliptic integrals of first and second kind (K and E)
 from scipy.special import ellipe, ellipk
 
-# Physical constants
+# magnetic permeability of free space
 mu0 = 4e-7 * pi
 
 
 class GSElliptic:
     """
-    Represents the Grad-Shafranov elliptic operator
+    Class representing the elliptc operator within the Grad-Shafranov
+    equation:
 
-    .. math::
-        \Delta^* = R^2 \nabla\cdot\frac{1}{R^2}\nabla
+        Δ^* = d^2/dR^2 + d^2/dZ^2 - (1/R)*d/dR
 
-    which is
-
-    .. math::
-        d^2/dR^2 + d^2/dZ^2 - (1/R)*d/dR
+        where:
+         -  R is the radial coordinate.
+         -  Z is the vertical coordinate.
 
     """
 
     def __init__(self, Rmin):
         """
-        Specify minimum radius
+        Initializes the class.
+
+        Parameters
+        ----------
+        Rmin : float
+            Minimum major radius [m].
 
         """
+
         self.Rmin = Rmin
 
     def __call__(self, psi, dR, dZ):
         """
-        Apply the full operator to 2D field f
+        Apply the elliptic operator to the flux function such that:
 
-        Inputs
-        ------
+            (Δ^*) * ψ.
 
-        psi[R,Z]   A 2D NumPy array containing flux function psi
-        dR         A scalar (uniform grid spacing)
-        dZ         A scalar (uniform grid spacing)
+        Computes to second-order accuracy.
 
+        Parameters
+        ----------
+        psi : np.array
+            The total poloidal flux at each (R,Z) grid point [Webers/2pi].
+        dR : float
+            Radial grid size [m].
+        dZ : float
+            Vertical grid size [m].
+
+        Returns
+        -------
+        np.array
+            The operator applied to the total poloidal flux.
         """
+
+        # number of radial and vertical grid points
         nx = psi.shape[0]
         ny = psi.shape[1]
 
+        # to store output
         b = zeros([nx, ny])
 
+        # pre-compute constants
         invdR2 = 1.0 / dR**2
         invdZ2 = 1.0 / dZ**2
 
+        # compute the operator (can be vectorised)
         for x in range(1, nx - 1):
             R = self.Rmin + dR * x  # Major radius of this point
             for y in range(1, ny - 1):
@@ -86,18 +107,58 @@ class GSElliptic:
 
     def diag(self, dR, dZ):
         """
-        Return the diagonal elements
+        Computes:
 
+            -2 * ( (1/dR^2) + (1/dZ^2) ).
+
+        Parameters
+        ----------
+        dR : float
+            Radial grid size [m].
+        dZ : float
+            Vertical grid size [m].
+
+        Returns
+        -------
+        float
+            The value above.
         """
         return -2.0 / dR**2 - 2.0 / dZ**2
 
 
 class GSsparse:
     """
-    Calculates sparse matrices for the Grad-Shafranov operator
+    Class representing the elliptc operator within the Grad-Shafranov
+    equation:
+
+        Δ^* = d^2/dR^2 + d^2/dZ^2 - (1/R)*d/dR
+
+        where:
+         -  R is the radial coordinate.
+         -  Z is the vertical coordinate.
+
+    This class calculates the sparse version to second-order accuracy.
+
     """
 
     def __init__(self, Rmin, Rmax, Zmin, Zmax):
+        """
+        Initializes the class.
+
+        Parameters
+        ----------
+        Rmin : float
+            Minimum major radius [m].
+        Rmax : float
+            Maximum major radius [m].
+        Zmin : float
+            Minimum height [m].
+        Zmax : float
+            Maximum height [m].
+
+        """
+
+        # set parameters
         self.Rmin = Rmin
         self.Rmax = Rmax
         self.Zmin = Zmin
@@ -105,23 +166,37 @@ class GSsparse:
 
     def __call__(self, nx, ny):
         """
-        Create a sparse matrix with given resolution
+        Generates the sparse elliptic operator Δ^* for a given number of
+        grid points. Computes to second-order accuracy.
 
+        Parameters
+        ----------
+        nx : int
+            Number of radial grid points (must be of form 2^n + 1, n=0,1,2,3,4,5,...).
+        ny : int
+            Number of vertical grid points (must be of form 2^n + 1, n=0,1,2,3,4,5,...).
+
+        Returns
+        -------
+        np.array
+            The operator matrix.
         """
 
-        # Calculate grid spacing
+        # calculate grid spacing
         dR = (self.Rmax - self.Rmin) / (nx - 1)
         dZ = (self.Zmax - self.Zmin) / (ny - 1)
 
-        # Total number of points
+        # total number of points
         N = nx * ny
 
-        # Create a linked list sparse matrix
+        # create a linked list sparse matrix
         A = eye(N, format="lil")
 
+        # pre-compute constants
         invdR2 = 1.0 / dR**2
         invdZ2 = 1.0 / dZ**2
 
+        # generate the operator values (can be optimsied)
         for x in range(1, nx - 1):
             R = self.Rmin + dR * x  # Major radius of this point
             for y in range(1, ny - 1):
@@ -143,14 +218,23 @@ class GSsparse:
                 # y+1
                 A[row, row + 1] = invdZ2
 
-        # Convert to Compressed Sparse Row (CSR) format
+        # convert to Compressed Sparse Row (CSR) format
         return A.tocsr()
 
 
 class GSsparse4thOrder:
     """
-    Calculates sparse matrices for the Grad-Shafranov operator using 4th-order
-    finite differences.
+    Class representing the elliptc operator within the Grad-Shafranov
+    equation:
+
+        Δ^* = d^2/dR^2 + d^2/dZ^2 - (1/R)*d/dR
+
+        where:
+         -  R is the radial coordinate.
+         -  Z is the vertical coordinate.
+
+    This class calculates the sparse version to fourth-order accuracy.
+
     """
 
     # Coefficients for first derivatives
@@ -191,6 +275,23 @@ class GSsparse4thOrder:
     ]
 
     def __init__(self, Rmin, Rmax, Zmin, Zmax):
+        """
+        Initializes the class.
+
+        Parameters
+        ----------
+        Rmin : float
+            Minimum major radius [m].
+        Rmax : float
+            Maximum major radius [m].
+        Zmin : float
+            Minimum height [m].
+        Zmax : float
+            Maximum height [m].
+
+        """
+
+        # set parameters
         self.Rmin = Rmin
         self.Rmax = Rmax
         self.Zmin = Zmin
@@ -198,23 +299,37 @@ class GSsparse4thOrder:
 
     def __call__(self, nx, ny):
         """
-        Create a sparse matrix with given resolution
+        Generates the sparse elliptic operator Δ^* for a given number of
+        grid points. Computes to fourth-order accuracy.
 
+        Parameters
+        ----------
+        nx : int
+            Number of radial grid points (must be of form 2^n + 1, n=0,1,2,3,4,5,...).
+        ny : int
+            Number of vertical grid points (must be of form 2^n + 1, n=0,1,2,3,4,5,...).
+
+        Returns
+        -------
+        np.array
+            The operator matrix.
         """
 
-        # Calculate grid spacing
+        # calculate grid spacing
         dR = (self.Rmax - self.Rmin) / (nx - 1)
         dZ = (self.Zmax - self.Zmin) / (ny - 1)
 
-        # Total number of points, including boundaries
+        # total number of points, including boundaries
         N = nx * ny
 
-        # Create a linked list sparse matrix
+        # create a linked list sparse matrix
         A = lil_matrix((N, N))
 
+        # calculate constants
         invdR2 = 1.0 / dR**2
         invdZ2 = 1.0 / dZ**2
 
+        # calculate entries (can be vectorised)
         for x in range(1, nx - 1):
             R = self.Rmin + dR * x  # Major radius of this point
             for y in range(1, ny - 1):
@@ -257,7 +372,7 @@ class GSsparse4thOrder:
                     for offset, weight in self.centred_1st:
                         A[row, row + offset * ny] -= weight / (R * dR)
 
-        # Set boundary rows
+        # set boundary rows
         for x in range(nx):
             for y in [0, ny - 1]:
                 row = x * ny + y
@@ -267,25 +382,50 @@ class GSsparse4thOrder:
                 row = x * ny + y
                 A[row, row] = 1.0
 
-        # Convert to Compressed Sparse Row (CSR) format
+        # convert to Compressed Sparse Row (CSR) format
         return A.tocsr()
 
 
 def Greens(Rc, Zc, R, Z):
     """
-    Calculate poloidal flux at (R,Z) due to a unit current
-    at (Rc,Zc) using Greens function
+    Calculate poloidal flux at (R,Z) due to a single unit of current at
+    (Rc,Zc) using Greens function for the elliptic operator above. Greens
+    function is given by:
 
+        G(R, Z; Rc, Zc) = (μ0 / (2π)) * sqrt(R * Rc) * ((2 - k^2) * K(k^2) - 2 * E(k^2)) / k
+
+    where:
+     - k^2 = 4 R Rc / ((R + Rc)^2 + (Z - Zc)^2)
+     - k = sqrt(k^2)
+
+    and K(k^2) and E(k^2) are the complete elliptic integrals of the first
+    and second kind.
+
+    Parameters
+    ----------
+    Rc : float
+        Radial position where current is located [m].
+    Zc : float
+        Vertical position where current is located [m].
+    R : float
+        Radial position where poloidal flux is to be calcualted [m].
+    Z : float
+        Vertical position where poloidal flux is to be calcualted [m].
+
+    Returns
+    -------
+    float
+        Value of the poloidal flux at (R,Z).
     """
 
-    # Calculate k^2
+    # calculate k^2
     k2 = 4.0 * R * Rc / ((R + Rc) ** 2 + (Z - Zc) ** 2)
 
-    # Clip to between 0 and 1 to avoid nans e.g. when coil is on grid point
+    # clip to between 0 and 1 to avoid nans e.g. when coil is on grid point
     k2 = clip(k2, 1e-10, 1.0 - 1e-10)
     k = sqrt(k2)
 
-    # Note definition of ellipk, ellipe in scipy is K(k^2), E(k^2)
+    # note definition of ellipk, ellipe in scipy is K(k^2), E(k^2)
     return (
         (mu0 / (2.0 * pi))
         * sqrt(R * Rc)
@@ -296,10 +436,30 @@ def Greens(Rc, Zc, R, Z):
 
 def GreensBz(Rc, Zc, R, Z, eps=1e-4):
     """
-    Calculate vertical magnetic field at (R,Z)
-    due to unit current at (Rc, Zc)
+    Calculate vertical magnetic field at (R,Z) due to a single unit of current at
+    (Rc,Zc) using Greens function for the elliptic operator above.
 
-    Bz = (1/R) d psi/dR
+        Bz(R,Z) = (1/R) d psi/dR,
+
+    where psi is found with the Greens function finite difference.
+
+    Parameters
+    ----------
+    Rc : float
+        Radial position where current is located [m].
+    Zc : float
+        Vertical position where current is located [m].
+    R : float
+        Radial position where poloidal flux is to be calcualted [m].
+    Z : float
+        Vertical position where poloidal flux is to be calcualted [m].
+    eps : float
+        Small step size for numerical differentiation in the radial direction [m].
+
+    Returns
+    -------
+    float
+        Value of the vertical magnetic field at (R,Z) [T].
     """
 
     return (Greens(Rc, Zc, R + eps, Z) - Greens(Rc, Zc, R - eps, Z)) / (
@@ -309,10 +469,30 @@ def GreensBz(Rc, Zc, R, Z, eps=1e-4):
 
 def GreensBr(Rc, Zc, R, Z, eps=1e-4):
     """
-    Calculate radial magnetic field at (R,Z)
-    due to unit current at (Rc, Zc)
+    Calculate radial magnetic field at (R,Z) due to a single unit of current at
+    (Rc,Zc) using Greens function for the elliptic operator above.
 
-    Br = -(1/R) d psi/dZ
+        Br(R,Z) = -(1/R) d psi/dZ,
+
+    where psi is found with the Greens function finite difference.
+
+    Parameters
+    ----------
+    Rc : float
+        Radial position where current is located [m].
+    Zc : float
+        Vertical position where current is located [m].
+    R : float
+        Radial position where poloidal flux is to be calcualted [m].
+    Z : float
+        Vertical position where poloidal flux is to be calcualted [m].
+    eps : float
+        Small step size for numerical differentiation in the radial direction [m].
+
+    Returns
+    -------
+    float
+        Value of the radial magnetic field at (R,Z) [T].
     """
 
     return (Greens(Rc, Zc, R, Z - eps) - Greens(Rc, Zc, R, Z + eps)) / (
@@ -322,10 +502,29 @@ def GreensBr(Rc, Zc, R, Z, eps=1e-4):
 
 def GreensdBzdr(Rc, Zc, R, Z, eps=2e-3):
     """
-    Calculate derivative of vertical magnetic field at (R,Z)
-    due to unit current at (Rc, Zc)
+    Calculate radial derivative of vertical magnetic field at (R,Z) due to a
+    single unit of current at (Rc,Zc) using Greens function for the
+    elliptic operator above:
 
-    Bz = (1/R) d psi/dR
+        dBz/dR (R,Z) = (Bz(R + eps, Z) - Bz(R - eps, Z))/ 2 * eps.
+
+    Parameters
+    ----------
+    Rc : float
+        Radial position where current is located [m].
+    Zc : float
+        Vertical position where current is located [m].
+    R : float
+        Radial position where poloidal flux is to be calcualted [m].
+    Z : float
+        Vertical position where poloidal flux is to be calcualted [m].
+    eps : float
+        Small step size for numerical differentiation in the radial direction [m].
+
+    Returns
+    -------
+    float
+        Value of the derivative at (R,Z) [T/m].
     """
 
     return (GreensBz(Rc, Zc, R + eps, Z) - GreensBz(Rc, Zc, R - eps, Z)) / (
@@ -335,21 +534,62 @@ def GreensdBzdr(Rc, Zc, R, Z, eps=2e-3):
 
 def GreensdBrdz(Rc, Zc, R, Z, eps=2e-3):
     """
-    Calculate derivative of radial magnetic field at (R,Z)
-    due to unit current at (Rc, Zc)
+    Calculate vertical derivative of radial magnetic field at (R,Z) due to a
+    single unit of current at (Rc,Zc) using Greens function for the
+    elliptic operator above:
 
-    Bz = (1/R) d psi/dR
+        dBr/dZ (R,Z) = (Br(R, Z + eps) - Br(R, Z - eps))/ 2 * eps.
+
+    Parameters
+    ----------
+    Rc : float
+        Radial position where current is located [m].
+    Zc : float
+        Vertical position where current is located [m].
+    R : float
+        Radial position where poloidal flux is to be calcualted [m].
+    Z : float
+        Vertical position where poloidal flux is to be calcualted [m].
+    eps : float
+        Small step size for numerical differentiation in the vertical direction [m].
+
+    Returns
+    -------
+    float
+        Value of the derivative at (R,Z) [T/m].
     """
 
-    return GreensdBzdr(Rc, Zc, R, Z, eps)
+    return (GreensBr(Rc, Zc, R, Z + eps) - GreensBr(Rc, Zc, R, Z - eps)) / (
+        2.0 * eps
+    )
+    # return GreensdBzdr(Rc, Zc, R, Z, eps)
 
 
 def GreensdBzdz(Rc, Zc, R, Z, eps=2e-3):
     """
-    Calculate  derivative of  vertical magnetic field at (R,Z)
-    due to unit current at (Rc, Zc)
+    Calculate vertical derivative of vertical magnetic field at (R,Z) due to a
+    single unit of current at (Rc,Zc) using Greens function for the
+    elliptic operator above:
 
-    Bz = (1/R) d psi/dR
+        dBz/dZ (R,Z) = (Bz(R, Z + eps) - Bz(R, Z - eps))/ 2 * eps.
+
+    Parameters
+    ----------
+    Rc : float
+        Radial position where current is located [m].
+    Zc : float
+        Vertical position where current is located [m].
+    R : float
+        Radial position where poloidal flux is to be calcualted [m].
+    Z : float
+        Vertical position where poloidal flux is to be calcualted [m].
+    eps : float
+        Small step size for numerical differentiation in the vertical direction [m].
+
+    Returns
+    -------
+    float
+        Value of the derivative at (R,Z) [T/m].
     """
 
     return (GreensBz(Rc, Zc, R, Z + eps) - GreensBz(Rc, Zc, R, Z - eps)) / (
@@ -359,10 +599,29 @@ def GreensdBzdz(Rc, Zc, R, Z, eps=2e-3):
 
 def GreensdBrdr(Rc, Zc, R, Z, eps=2e-3):
     """
-    Calculate  derivative of  vertical magnetic field at (R,Z)
-    due to unit current at (Rc, Zc)
+    Calculate radial derivative of radial magnetic field at (R,Z) due to a
+    single unit of current at (Rc,Zc) using Greens function for the
+    elliptic operator above:
 
-    Bz = (1/R) d psi/dR
+        dBr/dR (R,Z) = (Br(R + eps, Z) - Br(R + pes, Z))/ 2 * eps.
+
+    Parameters
+    ----------
+    Rc : float
+        Radial position where current is located [m].
+    Zc : float
+        Vertical position where current is located [m].
+    R : float
+        Radial position where poloidal flux is to be calcualted [m].
+    Z : float
+        Vertical position where poloidal flux is to be calcualted [m].
+    eps : float
+        Small step size for numerical differentiation in the radial direction [m].
+
+    Returns
+    -------
+    float
+        Value of the derivative at (R,Z) [T/m].
     """
 
     return (GreensBr(Rc, Zc, R + eps, Z) - GreensBr(Rc, Zc, R - eps, Z)) / (


### PR DESCRIPTION
I've tidied up the documentation as best I can in equilibrium.py. 

By this I mean I've added proper documentation for each of the functions within the class, trying to define inputs/outputs and provide the user with an idea of the equations used to generate the different equilibrium quantities (this really needs to be done for the other source files too, though obviously this may take a while).

Also fixed a few functions which were providing outputs in an incorrect format and removed some legacy functions that I think are no longer used (see commented out code, can be removed fully if it's agreed they're no longer used. 

I've also added some new functions (I may have forgotten to list some, apologies):
- Bpol(R,Z) [poloidal magnetic field]
- psi_1D(R,Z) [1D psi vector between magnetic axis and LCFS]
- psiN_RZ(R,Z) [normalised psi field]
- psiN_1D(R,Z) [normalised psi 1D vector]
- LCFS triangularity (upper, lower, and total)
- LCFS squareness (upper outer, upper inner, lower outer, lower inner)
- LCFS area and circumference
- LCFS extreme points [min and max R and Z locations]
- geometric elongation (upper and lower)
- Shafranov shift
- closest point on wall to the LCFS
- rho_1D [toroidal flux between magnetic axis and LCFS]
- rhoN_1D [normalised toroidal flux between magnetic axis and LCFS]

How they each work should be fully explained in the new comments/docs within the function. Let me know if there are any mistakes or if they need adjusting. 

I've added examples of how to use these new functions into the 'example3' notebook in FreeGSNKE (see [pull request](https://gitlab.stfc.ac.uk/farscape-ws3/freegsnke/-/merge_requests/119)). 

Similar documentation improvements have been made to jtor.py and gradshafranov.py (functionality should remain unchanged). 