### PR TITLE
Separatrix patch

### DIFF
--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -27,8 +27,8 @@ import numpy as np
 import shapely as sh
 from numpy import array, exp, linspace, meshgrid, pi
 from scipy import interpolate
-from scipy.spatial.distance import pdist, squareform
 from scipy.integrate import cumulative_trapezoid, romb
+from scipy.spatial.distance import pdist, squareform
 
 from . import critical, machine, multigrid, polygons  # multigrid solver
 from .boundary import fixedBoundary, freeBoundary  # finds free-boundary
@@ -843,10 +843,10 @@ class Equilibrium:
         Return (ntheta x 2) array of (R,Z) points on the last closed
         flux surface (plasma boundary), equally spaced in the geometric
         poloidal angle.
-        
-        Sometimes there may be spurious points far from the core plasma (due to 
+
+        Sometimes there may be spurious points far from the core plasma (due to
         open field lines), we exclude these by setting an average threshold distance
-        between all the points (excluding those outside the threshold). 
+        between all the points (excluding those outside the threshold).
 
         Parameters
         ----------
@@ -854,19 +854,23 @@ class Equilibrium:
             Number of points on the boundary to return.
         stdev : int
             Number of standard deviations after which outliers are excluded.
-            
+
         Returns
         -------
         np.array
             (R,Z) points on the last closed flux surface (plasma boundary).
         """
-        
+
         # initial points on core boundary
-        points = np.array(critical.find_separatrix(self, ntheta=ntheta))[:, 0:2]
+        points = np.array(critical.find_separatrix(self, ntheta=ntheta))[
+            :, 0:2
+        ]
 
         # compute pairwise distances using pdist
-        dist_matrix = squareform(pdist(points))        # convert to square form
-        mean_distances = np.mean(dist_matrix, axis=1)  # mean distance for each point
+        dist_matrix = squareform(pdist(points))  # convert to square form
+        mean_distances = np.mean(
+            dist_matrix, axis=1
+        )  # mean distance for each point
 
         # define a threshold (median + n * standard deviations)
         threshold = np.median(mean_distances) + stdev * np.std(mean_distances)

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -852,7 +852,7 @@ class Equilibrium:
         ----------
         ntheta : int
             Number of points on the boundary to return.
-        stdev : int
+        stdev : float
             Number of standard deviations after which outliers are excluded.
 
         Returns
@@ -873,7 +873,7 @@ class Equilibrium:
         )  # mean distance for each point
 
         # define a threshold (median + n * standard deviations)
-        threshold = np.median(mean_distances) + stdev * np.std(mean_distances)
+        threshold = np.median(mean_distances) + stdev * np.quantile(dist_matrix.reshape(-1), q=.8)
 
         # filter points
         filtered_points = points[mean_distances < threshold]

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -873,7 +873,9 @@ class Equilibrium:
         )  # mean distance for each point
 
         # define a threshold (median + n * standard deviations)
-        threshold = np.median(mean_distances) + stdev * np.quantile(dist_matrix.reshape(-1), q=.8)
+        threshold = np.median(mean_distances) + stdev * np.quantile(
+            dist_matrix.reshape(-1), q=0.8
+        )
 
         # filter points
         filtered_points = points[mean_distances < threshold]

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -27,6 +27,7 @@ import numpy as np
 import shapely as sh
 from numpy import array, exp, linspace, meshgrid, pi
 from scipy import interpolate
+from scipy.spatial.distance import pdist, squareform
 from scipy.integrate import cumulative_trapezoid, romb
 
 from . import critical, machine, multigrid, polygons  # multigrid solver
@@ -837,24 +838,43 @@ class Equilibrium:
 
         return self._profiles.pressure(psinorm)
 
-    def separatrix(self, ntheta=360):
+    def separatrix(self, ntheta=360, stdev=4):
         """
         Return (ntheta x 2) array of (R,Z) points on the last closed
         flux surface (plasma boundary), equally spaced in the geometric
         poloidal angle.
+        
+        Sometimes there may be spurious points far from the core plasma (due to 
+        open field lines), we exclude these by setting an average threshold distance
+        between all the points (excluding those outside the threshold). 
 
         Parameters
         ----------
         ntheta : int
             Number of points on the boundary to return.
-
+        stdev : int
+            Number of standard deviations after which outliers are excluded.
+            
         Returns
         -------
         np.array
             (R,Z) points on the last closed flux surface (plasma boundary).
         """
+        
+        # initial points on core boundary
+        points = np.array(critical.find_separatrix(self, ntheta=ntheta))[:, 0:2]
 
-        return array(critical.find_separatrix(self, ntheta=ntheta))[:, 0:2]
+        # compute pairwise distances using pdist
+        dist_matrix = squareform(pdist(points))        # convert to square form
+        mean_distances = np.mean(dist_matrix, axis=1)  # mean distance for each point
+
+        # define a threshold (median + n * standard deviations)
+        threshold = np.median(mean_distances) + stdev * np.std(mean_distances)
+
+        # filter points
+        filtered_points = points[mean_distances < threshold]
+
+        return filtered_points
 
     def separatrix_area(self):
         """


### PR DESCRIPTION
Minor patch that removes outlier points found when calculating the plasma boundary in 'separatrix()' in 'equilibrium.py. 

When 'ntheta' is large and the LCFS is "open", the critical.find_separatrix' function may sometimes return point(s) far from the LCFS due to the poloidal gap in the open flux surface. This patch removes those points (via a threshold distance that can be tweaked if needed). 

Do let me know if this isn't clear - I can draw some pictures if needed. 

