### PR TITLE
X-point treatment and Jtor refinement

### DIFF
--- a/freegs4e/coil.py
+++ b/freegs4e/coil.py
@@ -139,6 +139,18 @@ class Coil:
         calcPsiFromGreens()
         """
         return self.controlPsi(R, Z)
+    
+    def createBrGreensVec(self, R, Z):
+        """
+        Calculate Br Greens functions
+        """
+        return self.controlBr(R, Z)
+    
+    def createBzGreensVec(self, R, Z):
+        """
+        Calculate Bz Greens functions
+        """
+        return self.controlBz(R, Z)
 
     def calcPsiFromGreens(self, pgreen):
         """

--- a/freegs4e/coil.py
+++ b/freegs4e/coil.py
@@ -131,6 +131,14 @@ class Coil:
         calcPsiFromGreens()
         """
         return self.controlPsi(R, Z)
+    
+    def createPsiGreensVec(self, R, Z):
+        """
+        Calculate the Greens function at every point, and return
+        array. This will be passed back to evaluate Psi in
+        calcPsiFromGreens()
+        """
+        return self.controlPsi(R, Z)
 
     def calcPsiFromGreens(self, pgreen):
         """

--- a/freegs4e/coil.py
+++ b/freegs4e/coil.py
@@ -131,7 +131,7 @@ class Coil:
         calcPsiFromGreens()
         """
         return self.controlPsi(R, Z)
-    
+
     def createPsiGreensVec(self, R, Z):
         """
         Calculate the Greens function at every point, and return

--- a/freegs4e/coil.py
+++ b/freegs4e/coil.py
@@ -139,13 +139,13 @@ class Coil:
         calcPsiFromGreens()
         """
         return self.controlPsi(R, Z)
-    
+
     def createBrGreensVec(self, R, Z):
         """
         Calculate Br Greens functions
         """
         return self.controlBr(R, Z)
-    
+
     def createBzGreensVec(self, R, Z):
         """
         Calculate Bz Greens functions

--- a/freegs4e/critical.py
+++ b/freegs4e/critical.py
@@ -350,7 +350,7 @@ def scan_for_crit(R, Z, psi):
                 if det != 0:
                     delta_R = -(fR * fZZ - 0.5 * fRZ * fZ) / det
                     delta_Z = -(fZ * fRR - 0.5 * fRZ * fR) / det
-                if np.abs(delta_R) <= dR and np.abs(delta_Z) <= dZ:
+                if np.abs(delta_R) < 1.5*dR and np.abs(delta_Z) < 1.5*dZ:
                     est_psi = psi[i, j] + 0.5 * (
                         fR * delta_R + fZ * delta_Z
                     )  # + 0.5*(fRR*delta_R**2 + fZZ*delta_Z**2 + fRZ*delta_R*delta_Z)

--- a/freegs4e/critical.py
+++ b/freegs4e/critical.py
@@ -693,8 +693,12 @@ def inside_mask(
     psi_bndry=None,
     use_geom=True,
 ):
-    """Full identification of the diverted plasma core mask.
-    Combines inside_mask_ and geom_inside_mask.
+    """Full identification of the diverted plasma core mask. 
+    Combines inside_mask_ and geom_inside_mask. 
+    geom_inside_mask applies an additional geometrical contraint
+    aimed at resolving cases of 'flooding' of the core mask through the primary Xpoint.
+    It excludes regions based on perpendicular to segment
+    from O-point to primary X-point.
     """
     mask = inside_mask_(
         R, Z, psi, opoint, xpoint, mask_outside_limiter, psi_bndry

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -134,6 +134,7 @@ class Equilibrium:
         # generate Greens function mappings (used
         # in self.psi() to speed up calculations)
         self._pgreen = tokamak.createPsiGreens(self.R, self.Z)
+        self._vgreen = tokamak.createPsiGreensVec(self.R, self.Z)
         # self._updatePlasmaPsi(psi)  # Needs to be after _pgreen
 
         # assign plasma current

--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -926,6 +926,8 @@ class Lao85(Profile):
         # sum together
         Jtor = pprime_term + ffprime_term
 
+        Jtor *= (self.Ip*Jtor > 0)
+
         if torefine:
             return Jtor
 

--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -547,7 +547,9 @@ class ConstrainPaxisIp(Profile):
         """
 
         shape = (1.0 - np.clip(pn, 0.0, 1.0) ** self.alpha_m) ** self.alpha_n
-
+        if hasattr(self, 'L') is False:
+            self.L=1
+            print('This is using self.L=1. Please check if this is appropriate')
         return self.L * self.Beta0 / self.Raxis * shape
 
     def ffprime(self, pn):
@@ -567,7 +569,9 @@ class ConstrainPaxisIp(Profile):
         """
 
         shape = (1.0 - np.clip(pn, 0.0, 1.0) ** self.alpha_m) ** self.alpha_n
-
+        if hasattr(self, 'L') is False:
+            self.L=1
+            print('This is using self.L=1. Please check if this is appropriate')
         return mu0 * self.L * (1 - self.Beta0) * self.Raxis * shape
 
     def fvac(self):
@@ -713,7 +717,9 @@ class Fiesta_Topeol(Profile):
         """
 
         shape = (1.0 - np.clip(pn, 0.0, 1.0) ** self.alpha_m) ** self.alpha_n
-
+        if hasattr(self, 'L') is False:
+            self.L=1
+            print('This is using self.L=1. Please check if this is appropriate')
         return self.L * self.Beta0 / self.Raxis * shape
 
     def ffprime(self, pn):
@@ -733,7 +739,9 @@ class Fiesta_Topeol(Profile):
         """
 
         shape = (1.0 - np.clip(pn, 0.0, 1.0) ** self.alpha_m) ** self.alpha_n
-
+        if hasattr(self, 'L') is False:
+            self.L=1
+            print('This is using self.L=1. Please check if this is appropriate')
         return mu0 * self.L * (1 - self.Beta0) * self.Raxis * shape
 
     def fvac(self):

--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -814,9 +814,9 @@ class Lao85(Profile):
         beta : list or np.array
             Polynomial coefficients for ffprime.
         alpha_logic : bool
-            If True, include the n_{P+1} term (see Jtor2).
+            If True, include the n_{P+1} term to ensure pprime(1)=0 (see Jtor2).
         beta_logic : bool
-            If True, include the n_{F+1} term (see Jtor2).
+            If True, include the n_{F+1} term to ensure ffprime(1)=0 (see Jtor2).
         Raxis : float
             Radial scaling parameter (non-negative).
         Ip_logic : bool
@@ -945,6 +945,9 @@ class Lao85(Profile):
 
         # sum together
         Jtor = pprime_term + ffprime_term
+
+        # put to zero all current outside the LCFS
+        Jtor *= (psi > psi_bndry)
 
         Jtor *= (self.Ip*Jtor > 0)
 

--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -833,8 +833,17 @@ class Lao85(Profile):
             self.beta = np.concatenate((self.beta, [-np.sum(self.beta)]))
         self.beta_exp = np.arange(0, len(self.beta))
 
-    def Jtor_part2(self, R, Z, psi, psi_axis, psi_bndry, mask, 
-                   torefine=False, refineR=None):
+    def Jtor_part2(
+        self,
+        R,
+        Z,
+        psi,
+        psi_axis,
+        psi_bndry,
+        mask,
+        torefine=False,
+        refineR=None,
+    ):
         """
         Second part of the calculation that will use the explicit
         parameterisation of the chosen profile function to calculate Jtor.
@@ -865,7 +874,7 @@ class Lao85(Profile):
         mask : np.ndarray
             Mask of points inside the last closed flux surface.
 
-            
+
         Returns
         -------
         np.array
@@ -880,9 +889,9 @@ class Lao85(Profile):
         # grid sizes
         dR = R[1, 0] - R[0, 0]
         dZ = Z[0, 1] - Z[0, 0]
-        
+
         if torefine:
-            R = 1.0*refineR
+            R = 1.0 * refineR
 
         # calculate normalised psi
         psi_norm = (psi - psi_axis) / (psi_bndry - psi_axis)
@@ -890,14 +899,16 @@ class Lao85(Profile):
 
         # calculate the p' and FF' profiles
         pprime_term = (
-            psi_norm[np.newaxis, :, :] ** self.alpha_exp[:, np.newaxis, np.newaxis]
+            psi_norm[np.newaxis, :, :]
+            ** self.alpha_exp[:, np.newaxis, np.newaxis]
         )
         pprime_term *= self.alpha[:, np.newaxis, np.newaxis]
         pprime_term = np.sum(pprime_term, axis=0)
         pprime_term *= R / self.Raxis
 
         ffprime_term = (
-            psi_norm[np.newaxis, :, :] ** self.beta_exp[:, np.newaxis, np.newaxis]
+            psi_norm[np.newaxis, :, :]
+            ** self.beta_exp[:, np.newaxis, np.newaxis]
         )
         ffprime_term *= self.beta[:, np.newaxis, np.newaxis]
         ffprime_term = np.sum(ffprime_term, axis=0)
@@ -918,7 +929,9 @@ class Lao85(Profile):
             jtorIp = np.sum(Jtor)
             if jtorIp == 0:
                 self.problem_psi = psi
-                raise ValueError("Total plasma current is zero! Cannot renormalise.")
+                raise ValueError(
+                    "Total plasma current is zero! Cannot renormalise."
+                )
             L = self.Ip / (jtorIp * dR * dZ)
             Jtor = L * Jtor
         else:

--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -969,6 +969,9 @@ class Lao85(Profile):
             list(np.shape(self.alpha)) + [1] * len(shape_pn)
         )
         shape = np.sum(shape, axis=0)
+        if hasattr(self, 'L') is False:
+            self.L=1
+            print('This is using self.L=1. Please check if this is appropriate')
         return self.L * shape / self.Raxis
 
     def ffprime(self, pn):
@@ -997,6 +1000,9 @@ class Lao85(Profile):
             list(np.shape(self.beta)) + [1] * len(shape_pn)
         )
         shape = np.sum(shape, axis=0)
+        if hasattr(self, 'L') is False:
+            self.L=1
+            print('This is using self.L=1. Please check if this is appropriate')
         return self.L * shape * self.Raxis
 
     def pressure(self, pn):
@@ -1037,6 +1043,9 @@ class Lao85(Profile):
             ),
             axis=0,
         )
+        if hasattr(self, 'L') is False:
+            self.L=1
+            print('This is using self.L=1. Please check if this is appropriate')
         pressure = self.L * norm_pressure * (self.psi_axis - self.psi_bndry)
         return pressure
 

--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -205,7 +205,7 @@ class Profile(object):
                             self.edge_mask * alt_diverted_core_mask
                         )
                         if edge_pixels == 0:
-                            print("alternative xpt accepted!")
+                            print("Discarding 'primary' Xpoint! Please check final result")
                             xpt = xpt[1:]
                             psi_bndry = xpt[1, 2]
                             diverted_core_mask = alt_diverted_core_mask.copy()

--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -205,7 +205,9 @@ class Profile(object):
                             self.edge_mask * alt_diverted_core_mask
                         )
                         if edge_pixels == 0:
-                            print("Discarding 'primary' Xpoint! Please check final result")
+                            print(
+                                "Discarding 'primary' Xpoint! Please check final result"
+                            )
                             xpt = xpt[1:]
                             psi_bndry = xpt[1, 2]
                             diverted_core_mask = alt_diverted_core_mask.copy()

--- a/freegs4e/machine.py
+++ b/freegs4e/machine.py
@@ -509,7 +509,7 @@ class Machine:
 
         self.n_coils = len(coils)
         self.current_dummy_vec = np.zeros(self.n_coils)
-        self.current_vec = self.getCurrentVec()
+        self.getCurrentsVec()
         
         self.coil_names = list(self.getCurrents().keys())
         self.coil_order = {}
@@ -699,7 +699,7 @@ class Machine:
             currents[label] = coil.current
         return currents
     
-    def getCurrentVec(self):
+    def getCurrentsVec(self):
         """
         Returns an array of coil currents in Amps
         """
@@ -708,6 +708,7 @@ class Machine:
         for label, coil in self.coils:
             currents[i] = coil.current
             i += 1
+        self.current_vec = currents
         return currents
     
     def set_coil_current(self, coil_label, current_value):

--- a/freegs4e/machine.py
+++ b/freegs4e/machine.py
@@ -140,6 +140,24 @@ class Circuit:
         for label, coil, multiplier in self.coils:
             pgreen += multiplier * coil.createPsiGreens(R, Z)
         return pgreen
+    
+    def createBrGreensVec(self, R, Z):
+        """
+        Calculate Br Greens functions
+        """
+        pgreen = np.zeros(np.shape(R))
+        for label, coil, multiplier in self.coils:
+            pgreen += multiplier * coil.createBrGreensVec(R, Z)
+        return pgreen
+    
+    def createBzGreensVec(self, R, Z):
+        """
+        Calculate Bz Greens functions
+        """
+        pgreen = np.zeros(np.shape(R))
+        for label, coil, multiplier in self.coils:
+            pgreen += multiplier * coil.createBzGreensVec(R, Z)
+        return pgreen
 
     def calcPsiFromGreens(self, pgreen):
         """
@@ -584,6 +602,18 @@ class Solenoid:
         Calculate Greens functions
         """
         return self.controlPsi(R, Z)
+    
+    def createBrGreensVec(self, R, Z):
+        """
+        Calculate Br Greens functions
+        """
+        return self.controlBr(R, Z)
+    
+    def createBzGreensVec(self, R, Z):
+        """
+        Calculate Bz Greens functions
+        """
+        return self.controlBz(R, Z)
 
     def calcPsiFromGreens(self, pgreen):
         """
@@ -946,6 +976,7 @@ class Machine:
         self.wall = wall
 
         self.n_coils = len(coils)
+        self.current_vec = np.zeros(self.n_coils)
         self.current_dummy_vec = np.zeros(self.n_coils)
         self.getCurrentsVec()
 
@@ -1073,16 +1104,49 @@ class Machine:
             pgreen[label] = coil.createPsiGreens(R, Z)
         return pgreen
 
-    def createPsiGreensVec(self, R, Z):
+    def createPsiGreensVec(self, R, Z, coils=None):
         """
         Pre-computes the Greens functions
         and puts into arrays for each coil. This map can then be
         called at a later time, and quickly return the field
         """
-        pgreen = np.zeros([self.n_coils] + list(np.shape(R)))
+        if coils==None:
+            coils = self.coils
+
+        pgreen = np.zeros([len(coils)] + list(np.shape(R)))
         i = 0
-        for label, coil in self.coils:
+        for label, coil in coils:
             pgreen[i] = coil.createPsiGreensVec(R, Z)
+            i += 1
+        return pgreen
+    
+    def createBrGreensVec(self, R, Z, coils=None):
+        """
+        Pre-computes the Br Greens functions
+        and puts into arrays for each coil. 
+        """
+        if coils==None:
+            coils = self.coils
+
+        pgreen = np.zeros([len(coils)] + list(np.shape(R)))
+        i = 0
+        for label, coil in coils:
+            pgreen[i] = coil.createBrGreensVec(R, Z)
+            i += 1
+        return pgreen
+    
+    def createBzGreensVec(self, R, Z, coils=None):
+        """
+        Pre-computes the Br Greens functions
+        and puts into arrays for each coil. 
+        """
+        if coils==None:
+            coils = self.coils
+
+        pgreen = np.zeros([len(coils)] + list(np.shape(R)))
+        i = 0
+        for label, coil in coils:
+            pgreen[i] = coil.createBzGreensVec(R, Z)
             i += 1
         return pgreen
 
@@ -1333,13 +1397,16 @@ class Machine:
             currents[label] = coil.current
         return currents
 
-    def getCurrentsVec(self):
+    def getCurrentsVec(self, coils=None):
         """
         Returns an array of coil currents in Amps
         """
-        currents = np.zeros_like(self.current_dummy_vec)
+        if coils==None:
+            coils = self.coils
+
+        currents = np.zeros(len(coils))
         i = 0
-        for label, coil in self.coils:
+        for label, coil in coils:
             currents[i] = coil.current
             i += 1
         self.current_vec = currents

--- a/freegs4e/machine.py
+++ b/freegs4e/machine.py
@@ -666,8 +666,11 @@ class Machine:
         returned by controlCurrents
         """
         controlcoils = [coil for label, coil in self.coils if coil.control]
-        for coil, current in zip(controlcoils, currents):
-            coil.current = current
+        controlcoils_labels = [
+            label for label, coil in self.coils if coil.control
+        ]
+        for i in range(len(controlcoils_labels)):
+            self.set_coil_current(controlcoils_labels[i], currents[i])
 
     def printCurrents(self):
         print("==========================")

--- a/freegs4e/machine.py
+++ b/freegs4e/machine.py
@@ -99,7 +99,7 @@ class Circuit:
         for label, coil, multiplier in self.coils:
             pgreen[label] = coil.createPsiGreens(R, Z)
         return pgreen
-    
+
     def createPsiGreensVec(self, R, Z):
         """
         Calculate Greens functions
@@ -350,13 +350,13 @@ class Solenoid:
         Calculate Greens functions
         """
         return self.controlPsi(R, Z)
-    
+
     def createPsiGreensVec(self, R, Z):
         """
         Calculate Greens functions
         """
         return self.controlPsi(R, Z)
-    
+
     def calcPsiFromGreens(self, pgreen):
         """
         Calculate psi from Greens functions
@@ -510,10 +510,10 @@ class Machine:
         self.n_coils = len(coils)
         self.current_dummy_vec = np.zeros(self.n_coils)
         self.getCurrentsVec()
-        
+
         self.coil_names = list(self.getCurrents().keys())
         self.coil_order = {}
-        for i,coil in enumerate(self.coil_names):
+        for i, coil in enumerate(self.coil_names):
             self.coil_order[coil] = i
 
     def __repr__(self):
@@ -560,15 +560,15 @@ class Machine:
         for label, coil in self.coils:
             pgreen[label] = coil.createPsiGreens(R, Z)
         return pgreen
-    
+
     def createPsiGreensVec(self, R, Z):
         """
         Pre-computes the Greens functions
         and puts into arrays for each coil. This map can then be
         called at a later time, and quickly return the field
         """
-        pgreen = np.zeros([self.n_coils]+list(np.shape(R)))
-        i=0
+        pgreen = np.zeros([self.n_coils] + list(np.shape(R)))
+        i = 0
         for label, coil in self.coils:
             pgreen[i] = coil.createPsiGreensVec(R, Z)
             i += 1
@@ -583,12 +583,14 @@ class Machine:
         for label, coil in self.coils:
             psi_coils += coil.calcPsiFromGreens(pgreen[label])
         return psi_coils
-    
+
     def getPsitokamak(self, vgreen):
         """Uses self.current_vec and vgreen to calculate the plasma flux from all
         coils, active and passive
         """
-        tokamak_psi = np.sum(vgreen * self.current_vec[:,np.newaxis,np.newaxis], axis=0)
+        tokamak_psi = np.sum(
+            vgreen * self.current_vec[:, np.newaxis, np.newaxis], axis=0
+        )
         return tokamak_psi
 
     def Br(self, R, Z):
@@ -698,19 +700,19 @@ class Machine:
         for label, coil in self.coils:
             currents[label] = coil.current
         return currents
-    
+
     def getCurrentsVec(self):
         """
         Returns an array of coil currents in Amps
         """
         currents = np.zeros_like(self.current_dummy_vec)
-        i=0
+        i = 0
         for label, coil in self.coils:
             currents[i] = coil.current
             i += 1
         self.current_vec = currents
         return currents
-    
+
     def set_coil_current(self, coil_label, current_value):
         """Allows to set the current value of a coil
 
@@ -734,11 +736,11 @@ class Machine:
         current_vec : np.array
             Current values in Amps
         """
-        
-        self.current_vec[:len(current_vec)] = current_vec
+
+        self.current_vec[: len(current_vec)] = current_vec
         for i in range(len(current_vec)):
             self.coils[i][1].current = current_vec[i]
-        
+
     def plot(self, axis=None, show=True):
         """
         Plot the machine coils

--- a/freegs4e/machine.py
+++ b/freegs4e/machine.py
@@ -140,7 +140,7 @@ class Circuit:
         for label, coil, multiplier in self.coils:
             pgreen += multiplier * coil.createPsiGreens(R, Z)
         return pgreen
-    
+
     def createBrGreensVec(self, R, Z):
         """
         Calculate Br Greens functions
@@ -149,7 +149,7 @@ class Circuit:
         for label, coil, multiplier in self.coils:
             pgreen += multiplier * coil.createBrGreensVec(R, Z)
         return pgreen
-    
+
     def createBzGreensVec(self, R, Z):
         """
         Calculate Bz Greens functions
@@ -602,13 +602,13 @@ class Solenoid:
         Calculate Greens functions
         """
         return self.controlPsi(R, Z)
-    
+
     def createBrGreensVec(self, R, Z):
         """
         Calculate Br Greens functions
         """
         return self.controlBr(R, Z)
-    
+
     def createBzGreensVec(self, R, Z):
         """
         Calculate Bz Greens functions
@@ -1110,7 +1110,7 @@ class Machine:
         and puts into arrays for each coil. This map can then be
         called at a later time, and quickly return the field
         """
-        if coils==None:
+        if coils == None:
             coils = self.coils
 
         pgreen = np.zeros([len(coils)] + list(np.shape(R)))
@@ -1119,13 +1119,13 @@ class Machine:
             pgreen[i] = coil.createPsiGreensVec(R, Z)
             i += 1
         return pgreen
-    
+
     def createBrGreensVec(self, R, Z, coils=None):
         """
         Pre-computes the Br Greens functions
-        and puts into arrays for each coil. 
+        and puts into arrays for each coil.
         """
-        if coils==None:
+        if coils == None:
             coils = self.coils
 
         pgreen = np.zeros([len(coils)] + list(np.shape(R)))
@@ -1134,13 +1134,13 @@ class Machine:
             pgreen[i] = coil.createBrGreensVec(R, Z)
             i += 1
         return pgreen
-    
+
     def createBzGreensVec(self, R, Z, coils=None):
         """
         Pre-computes the Br Greens functions
-        and puts into arrays for each coil. 
+        and puts into arrays for each coil.
         """
-        if coils==None:
+        if coils == None:
             coils = self.coils
 
         pgreen = np.zeros([len(coils)] + list(np.shape(R)))
@@ -1401,7 +1401,7 @@ class Machine:
         """
         Returns an array of coil currents in Amps
         """
-        if coils==None:
+        if coils == None:
             coils = self.coils
 
         currents = np.zeros(len(coils))

--- a/freegs4e/plotting.py
+++ b/freegs4e/plotting.py
@@ -78,8 +78,8 @@ def plotIOConstraints(control, axis=None, show=True):
 
     """
 
-    import matplotlib.pyplot as plt
     import matplotlib
+    import matplotlib.pyplot as plt
 
     cmap = matplotlib.cm.get_cmap("gnuplot")
 

--- a/freegs4e/plotting.py
+++ b/freegs4e/plotting.py
@@ -80,7 +80,8 @@ def plotIOConstraints(control, axis=None, show=True):
 
     import matplotlib.pyplot as plt
     import matplotlib
-    cmap = matplotlib.cm.get_cmap('gnuplot')
+
+    cmap = matplotlib.cm.get_cmap("gnuplot")
 
     if axis is None:
         fig = plt.figure()
@@ -88,18 +89,28 @@ def plotIOConstraints(control, axis=None, show=True):
 
     # Locations of the X-points
     if control.null_points is not None:
-        axis.plot(control.null_points[0], control.null_points[1], "1", color='purple', markersize=10)
-        axis.plot([], [], "1", color='purple', markersize=10, label="Null-points")
+        axis.plot(
+            control.null_points[0],
+            control.null_points[1],
+            "1",
+            color="purple",
+            markersize=10,
+        )
+        axis.plot(
+            [], [], "1", color="purple", markersize=10, label="Null-points"
+        )
 
     # Isoflux surfaces
     if control.isoflux_set is not None:
         color = cmap(np.random.random())
-        for i,isoflux in enumerate(control.isoflux_set):
+        for i, isoflux in enumerate(control.isoflux_set):
             axis.plot(isoflux[0], isoflux[1], "+", color=color, markersize=10)
-            axis.plot([], [], "+", color=color, label=f"Isoflux_{i}", markersize=10)
+            axis.plot(
+                [], [], "+", color=color, label=f"Isoflux_{i}", markersize=10
+            )
 
     if show:
-        plt.legend(loc='upper right')
+        plt.legend(loc="upper right")
         plt.show()
 
     return axis

--- a/freegs4e/plotting.py
+++ b/freegs4e/plotting.py
@@ -69,6 +69,42 @@ def plotConstraints(control, axis=None, show=True):
     return axis
 
 
+def plotIOConstraints(control, axis=None, show=True):
+    """
+    Plots constraints used for coil current control
+
+    axis     - Specify the axis on which to plot
+    show     - Call matplotlib.pyplot.show() before returning
+
+    """
+
+    import matplotlib.pyplot as plt
+    import matplotlib
+    cmap = matplotlib.cm.get_cmap('gnuplot')
+
+    if axis is None:
+        fig = plt.figure()
+        axis = fig.add_subplot(111)
+
+    # Locations of the X-points
+    if control.null_points is not None:
+        axis.plot(control.null_points[0], control.null_points[1], "1", color='purple', markersize=10)
+        axis.plot([], [], "1", color='purple', markersize=10, label="Null-points")
+
+    # Isoflux surfaces
+    if control.isoflux_set is not None:
+        color = cmap(np.random.random())
+        for i,isoflux in enumerate(control.isoflux_set):
+            axis.plot(isoflux[0], isoflux[1], "+", color=color, markersize=10)
+            axis.plot([], [], "+", color=color, label=f"Isoflux_{i}", markersize=10)
+
+    if show:
+        plt.legend(loc='upper right')
+        plt.show()
+
+    return axis
+
+
 def plotEquilibrium(
     eq, axis=None, show=True, oxpoints=True, wall=True, limiter=True
 ):
@@ -107,7 +143,7 @@ def plotEquilibrium(
             xpt = eq._profiles.xpt
 
             for r, z, _ in xpt:
-                axis.plot(r, z, "ro")
+                axis.plot(r, z, "rx")
             for r, z, _ in opt:
                 axis.plot(r, z, "gx")
 
@@ -142,10 +178,10 @@ def plotEquilibrium(
                     )
 
                 # Add legend
-                axis.plot([], [], "ro", label="X-points")
+                axis.plot([], [], "rx", label="X-points")
                 axis.plot([], [], "r", label="Separatrix")
             if opt is not []:
-                axis.plot([], [], "go", label="O-points")
+                axis.plot([], [], "gx", label="O-points")
 
     except:
         print(


### PR DESCRIPTION
Added checks to choice of primary Xpoint to make static solver more stable. When the proposed primary Xpoint is such to generate a sudden change in plasma volume wrt previous calculations, the next Xpoint is considered.

Lao85 profile object set up for grid refinement.

I've also set things up so that the tokamak object keeps a vectorised version of the currents in all the coils, tokamak.current_vec. The equilibrium has the vectorised green functions at eq._vgreen (the dictionary eq._pgreen is still there). The two are used in combination by the forward_solve capability in freeGSNKE. Note that to allow for that, coil currents should not be set by directly modifying the attribute (e.g. coil.current=value), rather the newly added method of the tokamak object should be used, e.g. tokamak.set_coil_current(coil_label, value)