### PR TITLE
Find separatrix from equilibrium method

### DIFF
--- a/freegs4e/geqdsk.py
+++ b/freegs4e/geqdsk.py
@@ -116,9 +116,9 @@ def write(eq, fh, label=None, oxpoints=None, fileformat=_geqdsk.write):
     # rbdry, zbdry contain the boundary of the plasma
 
     isoflux = np.array(
-        critical.find_separatrix(
-            eq, ntheta=101, opoint=opoint, xpoint=xpoint, psi=psi
-        )
+        eq.separatrix(
+            ntheta=101,
+        ),
     )
 
     ind = np.argmin(isoflux[:, 1])


### PR DESCRIPTION
To allow GEQDSK output of updated FreeGSNKE equilibria, `isoflux` uses the equilibrium separatrix method to find separatrix. `ntheta` defaults remain the same.