### PR TITLE
Patching issue with rogue separatrix points

### DIFF
--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -839,12 +839,7 @@ class Equilibrium:
 
         return self._profiles.pressure(psinorm)
 
-    def separatrix(
-        self, 
-        ntheta=360, 
-        IQR_factor=2.0, 
-        verbose=False
-        ):
+    def separatrix(self, ntheta=360, IQR_factor=2.0, verbose=False):
         """
         Return (ntheta x 2) array of (R,Z) points on the last closed
         flux surface (plasma boundary), equally spaced in the geometric
@@ -853,7 +848,7 @@ class Equilibrium:
         Sometimes there may be spurious points far from the core plasma (due to
         open field lines), we exclude these by finding the minimum distance between points
         and then excluding those outside of some upper and lower bounds. These bounds can be
-        increased/decreased using IQR_factor. 
+        increased/decreased using IQR_factor.
 
         Parameters
         ----------
@@ -878,7 +873,9 @@ class Equilibrium:
         # compute pairwise distances using pdist
         dist_matrix = squareform(pdist(points))  # convert to square form
         # find minimum distances
-        min_dists = np.min(dist_matrix + 1e10 * np.eye(len(dist_matrix)), axis=0)
+        min_dists = np.min(
+            dist_matrix + 1e10 * np.eye(len(dist_matrix)), axis=0
+        )
 
         # calculate inter-quartlie ranges and bounds
         Q1 = np.percentile(min_dists, 25)
@@ -888,10 +885,12 @@ class Equilibrium:
         upper_bound = Q3 + IQR_factor * (Q3 - Q1)
 
         # identify outliers
-        outlier_indices = np.where((min_dists < lower_bound) | (min_dists > upper_bound))[0]
-        outliers = points[outlier_indices,:]
+        outlier_indices = np.where(
+            (min_dists < lower_bound) | (min_dists > upper_bound)
+        )[0]
+        outliers = points[outlier_indices, :]
 
-        # verbose 
+        # verbose
         if verbose:
             print("Outlier locations:", outliers)
 

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -877,7 +877,7 @@ class Equilibrium:
             dist_matrix + 1e10 * np.eye(len(dist_matrix)), axis=0
         )
 
-        # calculate inter-quartlie ranges and bounds
+        # calculate inter-quartile ranges and bounds
         Q1 = np.percentile(min_dists, 25)
         Q3 = np.percentile(min_dists, 75)
 

--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -175,7 +175,7 @@ class Profile(object):
             # check correct sorting between psi_axis and psi_bndry
             if (self.psi_axis - psi_bndry) * self.Ip < 0:
                 raise ValueError(
-                    "Incorrect critical points! Likely due to not suitable psi_plasma"
+                    "Incorrect critical points! Likely due to unsuitable 'psi_plasma' guess."
                 )
             diverted_core_mask = critical.inside_mask(
                 R, Z, psi, opt, xpt, mask_outside_limiter, psi_bndry
@@ -205,9 +205,9 @@ class Profile(object):
                             self.edge_mask * alt_diverted_core_mask
                         )
                         if edge_pixels == 0:
-                            print(
-                                "Discarding 'primary' Xpoint! Please check final result"
-                            )
+                            # print(
+                            #     "Discarding 'primary' Xpoint! Please check final result"
+                            # )
                             xpt = xpt[1:]
                             psi_bndry = xpt[1, 2]
                             diverted_core_mask = alt_diverted_core_mask.copy()


### PR DESCRIPTION
Here, I've patched an issue that cropped up where the function to find the points on the separatrix in equilibrium.py was returning spurious values (far ffrom the plasma core). This occurs when the plasma core has open field lines close to the X-point(s).

The updated method excludes any outlier points far from the true plasma core using inter-quartile ranges of the minimum distances between points. 