### PR TITLE
Plotting changes

### DIFF
--- a/freegs4e/plotting.py
+++ b/freegs4e/plotting.py
@@ -323,20 +323,18 @@ def plotEquilibrium(
     axis.set_ylabel("Height [m]")
 
     # plot flux contours
-    levels = linspace(amin(psi), amax(psi), 50)
+    levels = linspace(amin(psi), amax(psi), 35)
     axis.contour(eq.R, eq.Z, psi, levels=levels)
 
     # plot separatrix (from primary X-point)
-    if eq._profiles.flag_limiter:
-        label = "LCFS (limited plasma)"
-    else:
-        label = "Separatrix (primary X-point)"
     colour = "r"
     style = "solid"
     axis.contour(
-        eq.R, eq.Z, psi, levels=[eq.psi_bndry], colors=colour, linestyles=style
+        eq.R, eq.Z, psi, levels=[xpt[0][2]], colors=colour, linestyles=style
     )
-    axis.plot([], [], colour, label=label, linestyle=style)
+    axis.plot(
+        [], [], colour, label="Separatrix (primary X-point)", linestyle=style
+    )
 
     # plot extra separatrix (LCFS) if plasma limited
     if eq._profiles.flag_limiter:
@@ -346,7 +344,7 @@ def plotEquilibrium(
             eq.R,
             eq.Z,
             psi,
-            levels=[xpt[0][2]],
+            levels=[eq.psi_bndry],
             colors=colour,
             linestyles=style,
         )
@@ -354,7 +352,7 @@ def plotEquilibrium(
             [],
             [],
             colour,
-            label="Separatrix (primary X-point)",
+            label="LCFS (limited plasma)",
             linestyle=style,
         )
 


### PR DESCRIPTION
Small change ensuring that when plotting equilibria using the in-built method the PXPS (primary X-point separatrix) always remains solid red (for diverted or limited plasmas), while the LCFS for limited plasmas will be shown in dashed black. 

Also slightly reduced the default number of poloidal flux contour levels from 50 to 35 as they can be quite dense. 