### PR TITLE
Fix GEQDSK profile round trip

### DIFF
--- a/freegs4e/_geqdsk.py
+++ b/freegs4e/_geqdsk.py
@@ -184,7 +184,7 @@ def read(fh, cocos=1):
 
     cocos   - COordinate COnventions. Not fully handled yet,
               only whether psi is divided by 2pi or not.
-              if < 10 then psi is divided by 2pi, otherwise not.
+              if > 10 then psi is divided by 2pi, otherwise not.
 
     Returns
     -------

--- a/freegs4e/_geqdsk.py
+++ b/freegs4e/_geqdsk.py
@@ -288,6 +288,11 @@ def read(fh, cocos=1):
     if cocos > 10:
         for var in ["psi", "simagx", "sibdry"]:
             data[var] /= 2 * pi
+        # pprime and ffprime are derivatives with respect to psi. If the
+        # flux coordinate is divided by 2pi, derivatives with respect to that
+        # coordinate must be multiplied by 2pi.
+        for var in ["pprime", "ffprime"]:
+            data[var] *= 2 * pi
 
     nbdry = next(values)
     nlim = next(values)

--- a/freegs4e/control.py
+++ b/freegs4e/control.py
@@ -241,14 +241,14 @@ class ConstrainPsiNorm2D(object):
         psi = eq.psi()
 
         opt, xpt = critical.find_critical(eq.R, eq.Z, psi)
-        if not opt:
+        if len(opt) == 0:
             print("No O-points found!")
             print(opt, xpt)
             eq.plot()
             raise ValueError("No O-points found!")
         psi_axis = opt[0][2]
 
-        if not xpt:
+        if len(xpt) == 0:
             print("No X-points found!")
             eq.plot()
             raise ValueError("No X-points found")

--- a/freegs4e/critical.py
+++ b/freegs4e/critical.py
@@ -861,7 +861,7 @@ def inside_mask(
         # cure flooding
         mask = mask * geom_inside_mask(R, Z, opoint, xpoint)
         # apply geometric masking criterion to second Xpoint if close to double null
-        if len(xpoint > 1):
+        if len(xpoint) > 1:
             if (
                 np.abs(
                     (xpoint[0, 2] - xpoint[1, 2])

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -164,7 +164,7 @@ class Equilibrium:
             raise ValueError(
                 f"Shape of psi grid {psi.shape} must match grid size ({nx}, {ny})."
             )
-        self.plasma_psi = psi
+        self._updatePlasmaPsi(psi)
 
     def create_psi_plasma_default(
         self, adaptive_centre=False, gpars=(0.5, 0.5, 0, 2)
@@ -1882,6 +1882,11 @@ class Equilibrium:
             / (self.plasmaCurrent() ** 2)
         )
 
+    def poloidalBeta(self):
+        """Backward-compatible alias for :meth:`poloidalBeta1`."""
+
+        return self.poloidalBeta1()
+
     def poloidalBeta2(self):
         """
         Calculates poloidal beta from the following definition:
@@ -2686,6 +2691,8 @@ class Equilibrium:
 
         if len(xpt) > 0:
             self.psi_bndry = xpt[0][2]
+            if not hasattr(self, "mask_outside_limiter"):
+                self.mask_outside_limiter = np.zeros_like(psi, dtype=float)
             self.mask = critical.inside_mask(
                 self.R, self.Z, psi, opt, xpt, self.mask_outside_limiter
             )

--- a/freegs4e/geqdsk.py
+++ b/freegs4e/geqdsk.py
@@ -180,7 +180,7 @@ def read(
     cocos : integer
         COordinate COnventions. Not fully handled yet,
         only whether psi is divided by 2pi or not.
-        if < 10 then psi is divided by 2pi, otherwise not.
+        if > 10 then psi is divided by 2pi, otherwise not.
     domain : list/tuple of 4 elements
         Sets the (R,Z) domain to solve for
         (Rmin, Rmax, Zmin, Zmax)
@@ -265,16 +265,18 @@ def read(
 
     psinorm = linspace(0.0, 1.0, data["nx"], endpoint=True)
 
-    # Create a spline fit to pressure, f and f**2
+    # Create spline fits to pressure, f, pprime and ffprime.
+    # G-EQDSK stores pprime = dp/dpsi and ffprime = F dF/dpsi directly,
+    # so use those arrays rather than reconstructing them from p and F.
     p_spl = interpolate.InterpolatedUnivariateSpline(psinorm, data["pres"])
     pprime_spl = interpolate.InterpolatedUnivariateSpline(
-        psinorm, data["pres"] / psirange
-    ).derivative()
+        psinorm, data["pprime"]
+    )
 
     f_spl = interpolate.InterpolatedUnivariateSpline(psinorm, data["fpol"])
     ffprime_spl = interpolate.InterpolatedUnivariateSpline(
-        psinorm, 0.5 * data["fpol"] ** 2 / psirange
-    ).derivative()
+        psinorm, data["ffprime"]
+    )
 
     q_spl = interpolate.InterpolatedUnivariateSpline(psinorm, data["qpsi"])
 
@@ -304,13 +306,20 @@ def read(
             return reshape(q_spl(ravel(psinorm)), psinorm.shape)
         return q_spl(psinorm)
 
-    # Create a set of profiles to calculate toroidal current density Jtor
-    profiles = jtor.ProfilesPprimeFfprime(
-        pprime_func,
-        ffprime_func,
+    # Create a profile object to calculate toroidal current density Jtor.
+    # G-EQDSK supplies p, F and their derivatives on a normalised psi grid;
+    # the derivatives used here are with respect to the physical poloidal flux.
+    # Keep Ip_logic disabled so the imported pprime and ffprime profiles are
+    # used directly rather than renormalised after the first Jtor evaluation.
+    profiles = jtor.GeneralPprimeFFprime(
+        data["cpasma"],
         data["rcentr"] * data["bcentr"],
-        p_func=p_func,
-        f_func=f_func,
+        psinorm,
+        pprime_data=pprime_func(psinorm),
+        ffprime_data=ffprime_func(psinorm),
+        p_data=p_func(psinorm),
+        f_data=f_func(psinorm),
+        Ip_logic=False,
     )
 
     # Calculate normalised psi.
@@ -477,14 +486,12 @@ def read(
     psi = eq.psi()
     opoint, xpoint = critical.find_critical(eq.R, eq.Z, psi)
 
-    if xpoint:
+    if len(xpoint) > 0:
         # Use x-point and o-point constraints because the size of the grid may be changed
         # in which case the 2D psi constraints would fail
 
         # Find the separatrix
-        isoflux = critical.find_separatrix(
-            eq, opoint, xpoint, ntheta=ntheta, psi=psi, axis=axis
-        )
+        isoflux = critical.find_separatrix(eq, ntheta=ntheta, axis=axis)
 
         # Save the control system to eq
         eq.control = control.constrain(

--- a/freegs4e/geqdsk.py
+++ b/freegs4e/geqdsk.py
@@ -87,9 +87,7 @@ def write(eq, fh, label=None, oxpoints=None, fileformat=_geqdsk.write):
 
     data["cpasma"] = eq.plasmaCurrent()  # Plasma current [A]
 
-    psinorm = linspace(
-        0.0, 1.0, nx, endpoint=False
-    )  # Does not include separatrix
+    psinorm = linspace(0.0, 1.0, nx, endpoint=True)
 
     data["fpol"] = eq.fpol(psinorm)
     data["pres"] = eq.pressure(psinorm)

--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -76,10 +76,16 @@ class Profile(object):
         )
         if core_mask is None:
             core_mask = np.ones_like(psi, dtype=bool)
+        uses_xpoint_boundary = len(xpt) > 0 and np.isclose(
+            psi_bndry, xpt[0][2]
+        )
+        self.opt = opt
+        self.xpt = xpt
         self.psi_axis = opt[0][2]
         self.psi_bndry = psi_bndry
         self.diverted_core_mask = core_mask
         self.limiter_core_mask = core_mask
+        self.flag_limiter = not uses_xpoint_boundary
         return self.Jtor_part2(R, Z, psi, opt[0][2], psi_bndry, core_mask)
 
     def pressure(self, psinorm):

--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -36,6 +36,52 @@ class Profile(object):
     Base class from which profiles classes can inherit.
     """
 
+    def Jtor(self, R, Z, psi, psi_bndry=None):
+        """
+        Calculate the toroidal current density on the computational grid.
+
+        This convenience wrapper combines the generic critical-point and
+        core-mask identification in :meth:`Jtor_part1` with the profile-specific
+        current-density calculation implemented by each subclass in
+        :meth:`Jtor_part2`.
+
+        Parameters
+        ----------
+        R : np.ndarray
+            Radial coordinates of the grid points.
+        Z : np.ndarray
+            Vertical coordinates of the grid points.
+        psi : np.ndarray
+            Total poloidal field flux at each grid point [Webers/2pi].
+        psi_bndry : float, optional
+            Value of the poloidal field flux at the plasma boundary.
+
+        Returns
+        -------
+        np.array
+            Toroidal current density on the computational grid [A/m^2].
+        """
+
+        if not hasattr(self, "mask_inside_limiter"):
+            self.mask_inside_limiter = np.ones_like(psi, dtype=bool)
+        if not hasattr(self, "mask_outside_limiter"):
+            self.mask_outside_limiter = np.zeros_like(psi, dtype=float)
+
+        opt, xpt, core_mask, psi_bndry = self.Jtor_part1(
+            R,
+            Z,
+            psi,
+            psi_bndry=psi_bndry,
+            mask_outside_limiter=self.mask_outside_limiter,
+        )
+        if core_mask is None:
+            core_mask = np.ones_like(psi, dtype=bool)
+        self.psi_axis = opt[0][2]
+        self.psi_bndry = psi_bndry
+        self.diverted_core_mask = core_mask
+        self.limiter_core_mask = core_mask
+        return self.Jtor_part2(R, Z, psi, opt[0][2], psi_bndry, core_mask)
+
     def pressure(self, psinorm):
         """
         Calculate the 1D pressure profile in the plasma (vs. the normalised

--- a/freegs4e/test_geqdsk.py
+++ b/freegs4e/test_geqdsk.py
@@ -2,7 +2,72 @@ from io import StringIO
 
 import numpy
 
-from . import _geqdsk
+from . import _geqdsk, geqdsk, machine
+
+
+class SyntheticGeqdskEquilibrium:
+    """Small seeded diverted equilibrium used for G-EQDSK round-trip tests."""
+
+    def __init__(self, seed=4):
+        rng = numpy.random.default_rng(seed)
+        self.tokamak = machine.TestTokamak()
+        self.Rmin, self.Rmax = 0.4, 1.6
+        self.Zmin, self.Zmax = -0.8, 0.8
+        self.R_1D = numpy.linspace(self.Rmin, self.Rmax, 33)
+        self.Z_1D = numpy.linspace(self.Zmin, self.Zmax, 33)
+        self.R, self.Z = numpy.meshgrid(self.R_1D, self.Z_1D, indexing="ij")
+        self.R0 = 1.0 + 0.02 * rng.standard_normal()
+        self.lam = 1.45 + 0.05 * rng.random()
+        self._psi = -(
+            (self.R - self.R0) ** 2 + self.Z**2 - self.lam * self.Z**3
+        )
+        self._fvac = 1.8 + 0.1 * rng.random()
+        self._ip = 1.0e5 + 1.0e4 * rng.random()
+
+    def psi(self):
+        return self._psi
+
+    def fvac(self):
+        return self._fvac
+
+    def plasmaCurrent(self):
+        return self._ip
+
+    def fpol(self, psinorm):
+        psinorm = numpy.asarray(psinorm)
+        return self._fvac + 0.08 * (1.0 - psinorm) ** 2
+
+    def pressure(self, psinorm):
+        psinorm = numpy.asarray(psinorm)
+        return 1200.0 * (1.0 - psinorm) ** 2
+
+    def ffprime(self, psinorm):
+        psinorm = numpy.asarray(psinorm)
+        return self.fpol(psinorm) * (-0.16 * (1.0 - psinorm)) / self.psirange()
+
+    def pprime(self, psinorm):
+        psinorm = numpy.asarray(psinorm)
+        return -2400.0 * (1.0 - psinorm) / self.psirange()
+
+    def q(self, psinorm):
+        psinorm = numpy.asarray(psinorm)
+        return 1.0 + 0.2 * psinorm
+
+    def separatrix(self, ntheta=101):
+        theta = numpy.linspace(0.0, 2.0 * numpy.pi, ntheta, endpoint=False)
+        z_xpoint = 2.0 / (3.0 * self.lam)
+        radius = 0.8 * z_xpoint
+        return numpy.column_stack(
+            [
+                self.R0 + radius * numpy.cos(theta),
+                radius * numpy.sin(theta),
+            ]
+        )
+
+    def psirange(self):
+        z_xpoint = 2.0 / (3.0 * self.lam)
+        psi_xpoint = -(z_xpoint**2 - self.lam * z_xpoint**3)
+        return psi_xpoint
 
 
 def test_writeread():
@@ -47,3 +112,25 @@ def test_writeread():
     # Check that data and data2 are the same
     for key in data:
         numpy.testing.assert_allclose(data2[key], data[key])
+
+
+def test_equilibrium_geqdsk_write_read():
+    """Test that a seeded diverted equilibrium can be saved and loaded."""
+
+    eq = SyntheticGeqdskEquilibrium()
+    output = StringIO()
+
+    geqdsk.write(eq, output, label="SYNTH")
+    output.seek(0)
+
+    raw_data = _geqdsk.read(output)
+    psinorm = numpy.linspace(0.0, 1.0, raw_data["nx"], endpoint=False)
+    numpy.testing.assert_allclose(raw_data["pprime"], eq.pprime(psinorm))
+    numpy.testing.assert_allclose(raw_data["ffprime"], eq.ffprime(psinorm))
+
+    output.seek(0)
+    loaded = geqdsk.read(output, machine.TestTokamak(), rtol=1e2, maxits=1)
+
+    assert numpy.all(numpy.isfinite(loaded.psi()))
+    assert numpy.isfinite(loaded.plasmaCurrent())
+    assert numpy.isclose(loaded.pressure(0.0), eq.pressure(0.0))

--- a/freegs4e/test_geqdsk.py
+++ b/freegs4e/test_geqdsk.py
@@ -174,7 +174,9 @@ def test_equilibrium_geqdsk_write_read():
     output.seek(0)
 
     raw_data = _geqdsk.read(output)
-    psinorm = numpy.linspace(0.0, 1.0, raw_data["nx"], endpoint=False)
+    psinorm = numpy.linspace(0.0, 1.0, raw_data["nx"], endpoint=True)
+    numpy.testing.assert_allclose(raw_data["pres"], eq.pressure(psinorm))
+    numpy.testing.assert_allclose(raw_data["fpol"], eq.fpol(psinorm))
     numpy.testing.assert_allclose(raw_data["pprime"], eq.pprime(psinorm))
     numpy.testing.assert_allclose(raw_data["ffprime"], eq.ffprime(psinorm))
 
@@ -183,4 +185,17 @@ def test_equilibrium_geqdsk_write_read():
 
     assert numpy.all(numpy.isfinite(loaded.psi()))
     assert numpy.isfinite(loaded.plasmaCurrent())
-    assert numpy.isclose(loaded.pressure(0.0), eq.pressure(0.0))
+
+    profile_points = numpy.linspace(0.0, 1.0, 9, endpoint=True)
+    for loaded_profile, reference_profile in [
+        (loaded.pressure, eq.pressure),
+        (loaded.fpol, eq.fpol),
+        (loaded.pprime, eq.pprime),
+        (loaded.ffprime, eq.ffprime),
+    ]:
+        numpy.testing.assert_allclose(
+            loaded_profile(profile_points),
+            reference_profile(profile_points),
+            rtol=1e-7,
+            atol=1e-8,
+        )

--- a/freegs4e/test_geqdsk.py
+++ b/freegs4e/test_geqdsk.py
@@ -114,6 +114,56 @@ def test_writeread():
         numpy.testing.assert_allclose(data2[key], data[key])
 
 
+def test_cocos_flux_derivative_scaling():
+    """Test that COCOS flux conversion also rescales psi derivatives."""
+
+    nx = 5
+    ny = 5
+    data = {
+        "nx": nx,
+        "ny": ny,
+        "rdim": 2.0,
+        "zdim": 1.5,
+        "rcentr": 1.2,
+        "bcentr": 2.42,
+        "rleft": 0.5,
+        "zmid": 0.1,
+        "rmagx": 1.1,
+        "zmagx": 0.2,
+        "simagx": -2.3,
+        "sibdry": 0.21,
+        "cpasma": 1234521,
+        "fpol": numpy.linspace(1.0, 2.0, nx),
+        "pres": numpy.linspace(10.0, 0.0, nx),
+        "ffprime": numpy.linspace(0.2, 0.6, nx),
+        "pprime": numpy.linspace(-4.0, -1.0, nx),
+        "qpsi": numpy.linspace(1.0, 3.0, nx),
+        "psi": numpy.arange(nx * ny).reshape(nx, ny),
+    }
+
+    output = StringIO()
+    _geqdsk.write(data, output)
+    output.seek(0)
+
+    converted = _geqdsk.read(output, cocos=11)
+
+    numpy.testing.assert_allclose(
+        converted["psi"], data["psi"] / (2 * numpy.pi)
+    )
+    numpy.testing.assert_allclose(
+        converted["simagx"], data["simagx"] / (2 * numpy.pi)
+    )
+    numpy.testing.assert_allclose(
+        converted["sibdry"], data["sibdry"] / (2 * numpy.pi)
+    )
+    numpy.testing.assert_allclose(
+        converted["pprime"], data["pprime"] * (2 * numpy.pi)
+    )
+    numpy.testing.assert_allclose(
+        converted["ffprime"], data["ffprime"] * (2 * numpy.pi)
+    )
+
+
 def test_equilibrium_geqdsk_write_read():
     """Test that a seeded diverted equilibrium can be saved and loaded."""
 

--- a/freegs4e/test_jtor.py
+++ b/freegs4e/test_jtor.py
@@ -29,3 +29,25 @@ def test_psinorm_range():
         assert profiles.ffprime(1.0) == 0.0
         assert profiles.ffprime(1.1) == 0.0
         assert np.isfinite(profiles.ffprime(-0.32))
+
+
+def test_profile_jtor_stores_plotting_metadata():
+    """Test that the generic Jtor wrapper records downstream metadata."""
+
+    profiles = jtor.ConstrainBetapIp(1.0, 2e5, 2.0)
+    R, Z = np.meshgrid(
+        np.linspace(0.5, 1.5, 33), np.linspace(-1, 1, 33), indexing="ij"
+    )
+    psi = np.exp((-((R - 1.0) ** 2) - Z**2) * 3) + np.exp(
+        (-((R - 1.0) ** 2) - (Z + 1) ** 2) * 3
+    )
+
+    profiles.Jtor(R, Z, psi)
+
+    assert hasattr(profiles, "opt")
+    assert hasattr(profiles, "xpt")
+    assert hasattr(profiles, "flag_limiter")
+    assert hasattr(profiles, "psi_axis")
+    assert hasattr(profiles, "psi_bndry")
+    assert hasattr(profiles, "diverted_core_mask")
+    assert hasattr(profiles, "limiter_core_mask")


### PR DESCRIPTION
## Summary
- Fix high-level G-EQDSK read/write round-tripping by using the stored `pprime` and `ffprime` arrays directly with `GeneralPprimeFFprime`.
- Use a consistent profile grid from the magnetic axis through the separatrix when writing and reading G-EQDSK data.
- Initialise imported equilibria through `_updatePlasmaPsi` so `psi_func` and plasma masks are available immediately after load.
- Add a generic `Profile.Jtor` convenience wrapper for plain FreeGS4E profiles and fix array truth-value checks in critical/control paths.
- Correct the documented low-level `cocos` 2pi scaling condition.
- Add a seeded synthetic diverted-equilibrium write/read test that checks `p`, `F`, `pprime`, and `ffprime` across the full normalised-flux range.

## Checks
- `python -m pytest -q freegs4e/test_geqdsk.py freegs4e/test_jtor.py freegs4e/test_equilibrium.py::test_fixed_boundary_psi` -> `6 passed`.
- Full suite -> `45 passed, 2 failed`; both failing tests also fail on the base `main` branch.
- `black --check` and `isort --check-only` pass for the modified files.
- With the companion FreeGSNKE compatibility branch, ran setup plus the first two dynamic steps of `53320_2B-hhe-sxd_VCs_highres.ipynb`: `STEP_CHECK_OK`, `steps_completed=2`, `last_jtor_diff=0.0023029205285691272`.

Companion FreeGSNKE PR: https://github.com/FusionComputingLab/freegsnke/pull/81