### PR TITLE
Bump dependencies to latest compatible versions | Drop Python 3.9, 3.10, 3.11 support | Add Python 3.14 support

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 description = "Free boundary tokamak plasma equilibrium Grad-Shafranov solver for time evolution"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 classifiers = [
     "Programming Language :: Python :: 3",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,8 @@
-black==24.8.0
-isort==5.13.2
-flake8==7.1.1
+black==26.5.1
+isort==8.0.1
+flake8==7.3.0
 build
 ipython
 pre-commit
-pytest~=8.3
+pytest~=9.1
 twine

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
-numpy<2.0
-scipy~=1.9
-matplotlib~=3.0
-h5py~=3.11
-numba~=0.60
-Shapely~=2.0.6
+numpy>=2.0,<2.5
+scipy~=1.18
+matplotlib~=3.11
+h5py~=3.16
+numba~=0.66
+Shapely~=2.1


### PR DESCRIPTION
## Bump dependencies to latest compatible versions

### Reason for PR

A lot of the packages are quite out of date. For example, `numpy` 2.0 was released in June 2024...

The problem is that APIs are changing, for example, `numpy` has renamed `trapz` to `trapezoid`. My scripts use `trapezoid` and I need to run my scripts in a separate virtual environment to FreeGS4E. Which is annoying.

Also, the present dependencies also don't allow installing in Python 3.14.

### Summary

Minimal change that updates the project's Python dependencies to latest compatible versions.

No source code changed — only `requirements.txt`, `requirements-dev.txt`, and `pyproject.toml`

### Dropping Python 3.9, 3.10, and 3.11 support

The latest version of `scipy` is `1.18`. Which requires Python >= 3.12.

Python 3.9 is no longer receiving security updates. Python 3.10 -- 3.12 are not receiving bugfixs.

In my opinion - it's fine to drop old Python versions.

### Testing
Pre-change:
| Python | numpy | scipy | numba | matplotlib | Result |
|---|---|---|---|---|---|
| 3.9  | 1.26.4 | 1.13.1 | 0.60.0 | 3.9.4  | 39 passed, **5 failed** |
| 3.10 | 1.26.4 | 1.15.3 | 0.66.0 | 3.10.9 | 39 passed, **5 failed** |
| 3.11 | 1.26.4 | 1.17.1 | 0.66.0 | 3.11.1 | 39 passed, **5 failed** |
| 3.12 | 1.26.4 | 1.17.1 | 0.66.0 | 3.11.1 | 39 passed, **5 failed** |
| 3.13 | 1.26.4 | 1.17.1 | 0.66.0 | 3.11.1 | 39 passed, **5 failed** |
| 3.14 | <2.0 no py=3.14 wheel | — | — | — | **install failed** |

5 tests failed CI/CD before any changes. I propose we merge this and later tackle the failing tests.

Post-change:
| Python | numpy | scipy | numba | matplotlib | Result |
|---|---|---|---|---|---|
| 3.9  | — | ~=1.18 needs py≥3.12 | — | — | **install failed** |
| 3.10 | — | ~=1.18 needs py≥3.12 | — | — | **install failed** |
| 3.11 | — | ~=1.18 needs py≥3.12 | — | — | **install failed** |
| 3.12 | 2.4.6 | 1.18.0 | 0.66.0 | 3.11.1 | 39 passed, **5 failed** |
| 3.13 | 2.4.6 | 1.18.0 | 0.66.0 | 3.11.1 | 39 passed, **5 failed** |
| 3.14 | 2.4.6 | 1.18.0 | 0.66.0 | 3.11.1 | 39 passed, **5 failed** |

### Pre-existing failing tests
- [`test_critical.py::test_one_xpoint`](freegs4e/test_critical.py#L29) — `ValueError: No opoints found!`
- [`test_equilibrium.py::test_inoutseparatrix`](freegs4e/test_equilibrium.py#L6) — `AttributeError: 'Equilibrium' object has no attribute 'psi_func'`
- [`test_equilibrium.py::test_fixed_boundary_psi`](freegs4e/test_equilibrium.py#L25) — `AttributeError: 'Equilibrium' object has no attribute 'psi_func'`
- [`test_jtor.py::test_psinorm_range`](freegs4e/test_jtor.py#L6) — `AttributeError: ... has no attribute 'psi_func'`
- [`test_readwrite.py::test_readwrite`](freegs4e/test_readwrite.py#L8) — `AttributeError: 'Equilibrium' object has no attribute 'psi_func'`