### PR TITLE
Speed up tokamak flux contraction

### DIFF
--- a/freegs4e/machine.py
+++ b/freegs4e/machine.py
@@ -1568,13 +1568,17 @@ class Machine:
         return psi_coils
 
     def getPsitokamak(self, vgreen):
-        """Uses self.current_vec and vgreen to calculate the plasma flux from all
-        coils, active and passive
+        """Calculate plasma flux from all active and passive coil currents.
+
+        The leading axis of ``vgreen`` indexes coils. Flattening the spatial
+        axes expresses the weighted sum as one matrix multiplication, avoiding
+        the full-sized temporary array created by broadcast multiplication.
         """
-        tokamak_psi = np.sum(
-            vgreen * self.current_vec[:, np.newaxis, np.newaxis], axis=0
-        )
-        return tokamak_psi
+        spatial_shape = vgreen.shape[1:]
+        return (
+            self.current_vec
+            @ vgreen.reshape(vgreen.shape[0], np.prod(spatial_shape))
+        ).reshape(spatial_shape)
 
     def Br(self, R, Z):
         """

--- a/freegs4e/machine.py
+++ b/freegs4e/machine.py
@@ -1554,7 +1554,7 @@ class Machine:
         Parameters
         ----------
         pgreen : dict
-            Dictionary of Greens functions for the solenoid.
+            Dictionary of Greens functions for the active and passive coils.
 
         Returns
         -------
@@ -1568,11 +1568,25 @@ class Machine:
         return psi_coils
 
     def getPsitokamak(self, vgreen):
-        """Calculate plasma flux from all active and passive coil currents.
+        """
+        Calculate flux from all active and passive coil currents.
 
         The leading axis of ``vgreen`` indexes coils. Flattening the spatial
         axes expresses the weighted sum as one matrix multiplication, avoiding
         the full-sized temporary array created by broadcast multiplication.
+
+        Parameters
+        ----------
+        vgreen : np.array
+            Array of Greens functions for the active and passive coils.
+
+        Returns
+        -------
+        np.array
+            Poloidal flux from Greens functions [Webers/2pi].
+        """
+
+        """
         """
         spatial_shape = vgreen.shape[1:]
         return (

--- a/freegs4e/test_machine.py
+++ b/freegs4e/test_machine.py
@@ -84,3 +84,28 @@ def test_coil_forces_unequal():
     # Vertical force is equal and opposite
     assert math.isclose(forces["P1"][1], -forces["P2"][1])
     assert forces["P1"][1] < 0.0  # Force downward towards other coil
+
+
+def test_get_psi_tokamak_matches_weighted_green_sum():
+    """The optimized contraction must preserve the coil-weighted flux sum."""
+
+    tokamak = machine.Machine(
+        [
+            ("P1", machine.Coil(1.0, 0.5)),
+            ("P2", machine.Coil(1.5, 0.0)),
+            ("P3", machine.Coil(2.0, -0.5)),
+        ]
+    )
+    tokamak.set_all_coil_currents(np.array([125.0, -40.0, 310.0]))
+
+    vgreen = np.random.default_rng(42).normal(size=(3, 17, 25))
+    expected = np.sum(
+        vgreen * tokamak.current_vec[:, np.newaxis, np.newaxis], axis=0
+    )
+
+    np.testing.assert_allclose(tokamak.getPsitokamak(vgreen), expected)
+
+    empty_vgreen = np.empty((0, 17, 25))
+    np.testing.assert_array_equal(
+        machine.Machine([]).getPsitokamak(empty_vgreen), np.zeros((17, 25))
+    )


### PR DESCRIPTION
## Summary

- express the active/passive coil Green-function weighted sum as a matrix multiplication over flattened spatial axes
- avoid the full-sized temporary array produced by broadcast multiplication
- preserve empty-machine behaviour by reshaping with an explicit spatial size
- add regression coverage against the original weighted sum and for zero-coil machines

## Performance

For a 163-element machine, using one BLAS thread:

| Grid | Original | Matrix contraction | Speedup |
|---|---:|---:|---:|
| 65 x 129 | 0.533 ms | 0.244 ms | 2.19x |
| 129 x 257 | 4.776 ms | 1.142 ms | 4.18x |
| 193 x 385 | 11.478 ms | 2.575 ms | 4.46x |

The maximum absolute numerical difference was below `7e-17`.

## Validation

- `pytest freegs4e/test_machine.py -q`: 4 passed
- FreeGSNKE static forward regression using this FreeGS4E checkout: passed
