### PR TITLE
Fix alternative X-point and geometric mask handling

### DIFF
--- a/freegs4e/critical.py
+++ b/freegs4e/critical.py
@@ -870,26 +870,24 @@ def inside_mask(
 def geom_inside_mask(R, Z, opoint, xpoint):
     """
 
-    This function excludes grid regions based on a line perpendicular
-    to the segment from the O-point to the primary X-point in the plasma core.
-    A dot product retains the half-plane containing the O-point.
+    Excludes grid regions based on a line perpendicular to the segment from
+    the O-point to the primary X-point. Points on the O-point's side of that
+    line are considered part of the plasma core.
 
     Parameters
     ----------
-    R : np.array
-        Radial positions at which flux measured.
-    Z : np.array
-        Vertical positions at which flux measured.
-    opoint : list
-        The list of O-point tuples (R,Z,psi).
-    xpoint : list
-        The list of X-point tuples (R,Z,psi).
+    R, Z : ndarray
+        Grid coordinates.
+    opoint : ndarray, shape (1, 2)
+        (R, Z) coordinates of the O-point.
+    xpoint : ndarray, shape (1, 2)
+        (R, Z) coordinates of the primary X-point.
 
     Returns
     -------
-    np.array
-        Returns a 2D Boolean array (at (R,Z) locations) where 1 denotes a point inside
-        the core and 0 denostes a point outside.
+    geom_mask : ndarray of bool
+        True where the grid point lies in the core (O-point) half-plane,
+        False otherwise.
     """
 
     delta_R = opoint[0, 0] - xpoint[0, 0]

--- a/freegs4e/critical.py
+++ b/freegs4e/critical.py
@@ -845,7 +845,7 @@ def inside_mask(
         Total poloidal flux on the plasma boundary [Webers/2pi].
     use_geom : bool
         Use (refined) geom_inside_mask function in conjuction with inside_mask_
-        to find the mask (if set to True).
+        to find the mask when at least one X-point is available (if set to True).
 
     Returns
     -------
@@ -857,11 +857,11 @@ def inside_mask(
     mask = inside_mask_(
         R, Z, psi, opoint, xpoint, mask_outside_limiter, psi_bndry
     )
-    if use_geom:
+    if use_geom and len(xpoint) > 0:
         # cure flooding
         mask = mask * geom_inside_mask(R, Z, opoint, xpoint)
         # apply geometric masking criterion to second Xpoint if close to double null
-        if len(xpoint > 1):
+        if len(xpoint) > 1:
             if (
                 np.abs(
                     (xpoint[0, 2] - xpoint[1, 2])
@@ -878,6 +878,7 @@ def geom_inside_mask(R, Z, opoint, xpoint):
 
     This function excludes grid regions based on a line perpendicular
     to the segment from the O-point to the primary X-point in the plasma core.
+    A dot product retains the half-plane containing the O-point.
 
     Parameters
     ----------
@@ -897,12 +898,10 @@ def geom_inside_mask(R, Z, opoint, xpoint):
         the core and 0 denostes a point outside.
     """
 
-    slope = -(opoint[0, 0] - xpoint[0, 0]) / (opoint[0, 1] - xpoint[0, 1])
-    interc = xpoint[0, 1] - slope * xpoint[0, 0]
-
+    delta_R = opoint[0, 0] - xpoint[0, 0]
+    delta_Z = opoint[0, 1] - xpoint[0, 1]
     geom_mask = (
-        (opoint[0, 1] - (slope * opoint[0, 0] + interc))
-        * (Z - (slope * R + interc))
+        delta_R * (R - xpoint[0, 0]) + delta_Z * (Z - xpoint[0, 1])
     ) > 0
 
     return geom_mask

--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -178,23 +178,22 @@ class Profile(object):
             if hasattr(self, "diverted_core_mask"):
                 if self.diverted_core_mask is not None:
                     previous_core_size = np.sum(self.diverted_core_mask)
-                    skipped_xpts = 0
                     # check size change
                     check = (
                         np.sum(diverted_core_mask) / previous_core_size < 0.5
                     )
-                    # check there's more candidates
-                    check *= len(xpt) > 1
-                    while check:
-                        # try using second xpt as primary xpt
+                    candidate_index = 1
+                    while check and candidate_index < len(xpt):
+                        # try using the next xpt as primary xpt
+                        candidate_xpt = xpt[candidate_index:]
                         alt_diverted_core_mask = critical.inside_mask(
                             R,
                             Z,
                             psi,
                             opt,
-                            xpt[1:],
+                            candidate_xpt,
                             mask_outside_limiter,
-                            xpt[1, 2],
+                            candidate_xpt[0, 2],
                         )
                         # check the alternative Xpoint gives rise to a valid core
                         edge_pixels = np.sum(
@@ -202,8 +201,8 @@ class Profile(object):
                         )
                         if edge_pixels == 0:
                             # the candidate is valid
-                            xpt = xpt[1:]
-                            psi_bndry = xpt[1, 2]
+                            xpt = candidate_xpt
+                            psi_bndry = xpt[0, 2]
                             diverted_core_mask = alt_diverted_core_mask.copy()
 
                             # check if there could be better candidates
@@ -211,8 +210,9 @@ class Profile(object):
                                 np.sum(diverted_core_mask) / previous_core_size
                                 < 0.5
                             )
-                            # check there's more candidates
-                            check *= len(xpt) > 1
+                            candidate_index = 1
+                        else:
+                            candidate_index += 1
         else:
             # No X-points
             psi_bndry = psi[0, 0]

--- a/freegs4e/test_critical.py
+++ b/freegs4e/test_critical.py
@@ -100,7 +100,45 @@ def test_mask_zero_psi_bndry():
     assert np.isclose(opoints[0][1], z0, atol=1.0 / ny)
 
     mask = critical.core_mask(r2d, z2d, psi, opoints, xpoints, psi_bndry=0.0)
+    inside_mask = critical.inside_mask(
+        r2d, z2d, psi, opoints, xpoints, psi_bndry=0.0
+    )
+    inside_mask_without_guard = critical.inside_mask(
+        r2d, z2d, psi, opoints, xpoints, psi_bndry=0.0, use_geom=False
+    )
 
     # Some of the mask must equal 1, some 0
     assert np.any(np.equal(mask, 1))
     assert np.any(np.equal(mask, 0))
+    assert np.array_equal(inside_mask, inside_mask_without_guard)
+
+
+def test_inside_mask_single_xpoint_does_not_apply_double_null_guard():
+    nx = 21
+    ny = 41
+
+    r1d = np.linspace(0.5, 1.5, nx)
+    z1d = np.linspace(-1.0, 1.0, ny)
+    r2d, z2d = np.meshgrid(r1d, z1d, indexing="ij")
+
+    psi = (r2d - 1.0) ** 2 + z2d**2
+    opoints = np.array([[1.0, 0.0, 0.0]])
+    xpoints = np.array([[1.0, -0.8, 0.64]])
+
+    mask = critical.inside_mask(r2d, z2d, psi, opoints, xpoints)
+
+    assert mask.shape == psi.shape
+    assert mask.dtype == bool
+    assert np.any(mask)
+
+
+def test_geom_inside_mask_with_horizontally_aligned_xpoint():
+    r1d = np.linspace(0.5, 1.5, 21)
+    z1d = np.linspace(-1.0, 1.0, 41)
+    r2d, z2d = np.meshgrid(r1d, z1d, indexing="ij")
+    opoints = np.array([[1.5, 0.0, 1.0]])
+    xpoints = np.array([[1.0, 0.0, 0.0]])
+
+    mask = critical.geom_inside_mask(r2d, z2d, opoints, xpoints)
+
+    assert np.array_equal(mask, r2d > 1.0)

--- a/freegs4e/test_jtor.py
+++ b/freegs4e/test_jtor.py
@@ -29,3 +29,82 @@ def test_psinorm_range():
         assert profiles.ffprime(1.0) == 0.0
         assert profiles.ffprime(1.1) == 0.0
         assert np.isfinite(profiles.ffprime(-0.32))
+
+
+def _continuity_test_profile(shape):
+    profiles = jtor.ConstrainPaxisIp(1e3, 2e5, 2.0)
+    profiles.mask_inside_limiter = np.ones(shape, dtype=bool)
+    profiles.edge_mask = np.zeros(shape, dtype=bool)
+    profiles.edge_mask[[0, -1], :] = True
+    profiles.edge_mask[:, [0, -1]] = True
+    profiles.diverted_core_mask = np.zeros(shape, dtype=bool)
+    profiles.diverted_core_mask.flat[:16] = True
+    return profiles
+
+
+def test_alternative_xpoint_sets_matching_boundary(monkeypatch):
+    """An accepted alternative X-point also supplies the returned boundary flux."""
+    shape = (5, 5)
+    R, Z = np.meshgrid(np.arange(5.0), np.arange(5.0), indexing="ij")
+    psi = np.ones(shape)
+    opt = np.array([[2.0, 2.0, 1.0]])
+    xpt = np.array([[2.0, 1.0, 0.9], [2.0, 3.0, 0.8]])
+    primary_mask = np.zeros(shape, dtype=bool)
+    primary_mask[2:4, 2:4] = True
+    alternative_mask = np.zeros(shape, dtype=bool)
+    alternative_mask[1:4, 1:4] = True
+
+    monkeypatch.setattr(
+        jtor.critical, "find_critical", lambda *args: (opt, xpt)
+    )
+    monkeypatch.setattr(
+        jtor.critical,
+        "inside_mask",
+        lambda *args: (
+            primary_mask if np.isclose(args[-1], 0.9) else alternative_mask
+        ),
+    )
+
+    profiles = _continuity_test_profile(shape)
+    _, selected_xpt, mask, psi_bndry = profiles.Jtor_part1(R, Z, psi)
+
+    assert np.array_equal(selected_xpt, xpt[1:])
+    assert np.isclose(psi_bndry, selected_xpt[0, 2])
+    assert np.array_equal(mask, alternative_mask)
+
+
+def test_alternative_xpoint_search_advances_after_edge_mask(monkeypatch):
+    """An edge-touching alternative is skipped without stalling the search."""
+    shape = (5, 5)
+    R, Z = np.meshgrid(np.arange(5.0), np.arange(5.0), indexing="ij")
+    psi = np.ones(shape)
+    opt = np.array([[2.0, 2.0, 1.0]])
+    xpt = np.array([[2.0, 1.0, 0.9], [2.0, 3.0, 0.8], [3.0, 2.0, 0.7]])
+    primary_mask = np.zeros(shape, dtype=bool)
+    primary_mask[2:4, 2:4] = True
+    edge_mask = np.ones(shape, dtype=bool)
+    final_mask = np.zeros(shape, dtype=bool)
+    final_mask[1:4, 1:4] = True
+    boundaries = []
+
+    def inside_mask(*args):
+        psi_bndry = args[-1]
+        boundaries.append(psi_bndry)
+        if np.isclose(psi_bndry, 0.9):
+            return primary_mask
+        if np.isclose(psi_bndry, 0.8):
+            return edge_mask
+        return final_mask
+
+    monkeypatch.setattr(
+        jtor.critical, "find_critical", lambda *args: (opt, xpt)
+    )
+    monkeypatch.setattr(jtor.critical, "inside_mask", inside_mask)
+
+    profiles = _continuity_test_profile(shape)
+    _, selected_xpt, mask, psi_bndry = profiles.Jtor_part1(R, Z, psi)
+
+    assert np.allclose(boundaries, [0.9, 0.8, 0.7])
+    assert np.array_equal(selected_xpt, xpt[2:])
+    assert np.isclose(psi_bndry, selected_xpt[0, 2])
+    assert np.array_equal(mask, final_mask)

--- a/freegs4e/test_jtor.py
+++ b/freegs4e/test_jtor.py
@@ -51,7 +51,8 @@ def test_profile_jtor_stores_plotting_metadata():
     assert hasattr(profiles, "psi_bndry")
     assert hasattr(profiles, "diverted_core_mask")
     assert hasattr(profiles, "limiter_core_mask")
-    
+
+
 def _continuity_test_profile(shape):
     profiles = jtor.ConstrainPaxisIp(1e3, 2e5, 2.0)
     profiles.mask_inside_limiter = np.ones(shape, dtype=bool)


### PR DESCRIPTION
## Summary
- keep the accepted X-point, boundary flux, and plasma mask consistent while testing alternative X-points
- advance past edge-touching candidates instead of repeating the same candidate indefinitely
- guard single/no-X-point mask construction correctly
- replace the singular slope-based geometric guard with the equivalent dot-product half-plane test

## Corrections
The continuity loop previously read the boundary from the wrong X-point after accepting an alternative. It could also stall when an alternative mask touched the computational boundary. The geometric flood guard divided by `Zo - Zx`, making horizontally aligned O- and X-points singular, and was called even when no X-point existed.

## Verification
Focused regression tests cover accepted and rejected alternative candidates, single/no-X-point masks, and horizontal O/X alignment. Result: **5 passed**.