### PR TITLE
build: coordinate Python and dependency support with FreeGSNKE

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,30 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  tests:
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12", "3.14"]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install package and test dependencies
+        run: python -m pip install ".[dev]"
+      - name: Run compatibility suite
+        # These two tests also fail on main and are tracked separately from this
+        # dependency-compatibility change. Keep the remainder enforced here.
+        run: >-
+          python -m pytest -v
+          --deselect=freegs4e/test_critical.py::test_one_xpoint
+          --deselect=freegs4e/test_readwrite.py::test_readwrite

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ Given FreeGS4E is not a standalone equilibrium solver, we recommend following th
 
 If you would, however, like to contribute to FreeGS4E directly, please see the installation instructions in the section on contributing below.
 
+### Supported Python and dependencies
+
+FreeGS4E supports Python 3.10 through 3.14. Its runtime dependency bounds are
+kept compatible with FreeGSNKE, which uses a subset of the same scientific
+Python envelope. Changes to shared lower or upper bounds should therefore be
+tested in both repositories before release.
+
 ## Getting started
 
 All of the examples for getting started can be found within the `freegsnke/examples` directory.

--- a/freegs4e/critical.py
+++ b/freegs4e/critical.py
@@ -20,6 +20,8 @@ along with FreeGS4E.  If not, see <http://www.gnu.org/licenses/>.
 
 """
 
+import warnings
+
 import numpy as np
 from numpy import (
     abs,
@@ -47,9 +49,6 @@ except ImportError:
 
     def njit(*args, **kwargs):
         return lambda f: f
-
-
-import warnings
 
 from . import bilinear_interpolation
 

--- a/freegs4e/critical.py
+++ b/freegs4e/critical.py
@@ -50,6 +50,7 @@ except ImportError:
     def njit(*args, **kwargs):
         return lambda f: f
 
+
 from . import bilinear_interpolation
 
 # from unittest import makeSuite

--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -27,7 +27,7 @@ import numpy as np
 import shapely as sh
 from numpy import exp, linspace, meshgrid, pi
 from scipy import interpolate
-from scipy.integrate import cumulative_trapezoid
+from scipy.integrate import cumulative_trapezoid, trapezoid
 from scipy.optimize import least_squares
 from scipy.spatial.distance import pdist, squareform
 
@@ -1691,7 +1691,7 @@ class Equilibrium:
         Bp = self.Bpol(separatrix[:, 0], separatrix[:, 1])
 
         # integrate
-        integral_Bpol_lcfs = np.trapz(Bp, l)
+        integral_Bpol_lcfs = trapezoid(Bp, l)
 
         return integral_Bpol_2 / (
             (integral_Bpol_lcfs / self.separatrix_length()) ** 2
@@ -1985,7 +1985,7 @@ class Equilibrium:
         Bp = self.Bpol(separatrix[:, 0], separatrix[:, 1])
 
         # integrate
-        integral_Bpol_lcfs = np.trapz(Bp, l)
+        integral_Bpol_lcfs = trapezoid(Bp, l)
 
         return (pressure_integral / self.plasmaVolume()) / (
             integral_Bpol_lcfs / self.separatrix_length()
@@ -2596,8 +2596,8 @@ class Equilibrium:
             f_on_flux_surf = f(flux_surface[:, 0], flux_surface[:, 1])
 
             # integrate with trapezoidal rule
-            integral_f_inv_Bpol = np.trapz(f_on_flux_surf * Bp_inv, l)
-            integral_inv_Bpol = np.trapz(Bp_inv, l)
+            integral_f_inv_Bpol = trapezoid(f_on_flux_surf * Bp_inv, l)
+            integral_inv_Bpol = trapezoid(Bp_inv, l)
 
             flux_averaged_quantity[i] = integral_f_inv_Bpol / integral_inv_Bpol
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,15 +4,20 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "freegs4e"
-version = "0.13.1"
+version = "0.14.0"
 authors = [
     {name = "The FreeGS4E and FreeGS developers"}
 ]
 description = "Free boundary tokamak plasma equilibrium Grad-Shafranov solver for time evolution"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Operating System :: OS Independent"
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
-numpy<2.0
-scipy~=1.9
-matplotlib~=3.0
-h5py~=3.11
-numba~=0.60
-Shapely~=2.0.6
+# Keep these bounds compatible with FreeGSNKE's runtime requirements.
+numpy>=1.26.4,<2.5
+scipy>=1.15.3,<2
+matplotlib>=3.9,<4
+h5py>=3.11,<4
+numba>=0.60,<1
+Shapely>=2.0.6,<3


### PR DESCRIPTION
## Summary

- declare support for Python 3.10 through 3.14
- replace narrow historical pins with a bounded runtime envelope shared with FreeGSNKE
- replace removed `numpy.trapz` calls with `scipy.integrate.trapezoid` for NumPy 2.4 compatibility
- repair the documented no-Numba import fallback
- add a Python 3.10/3.12/3.14 compatibility matrix and document the cross-repository policy
- prepare the FreeGS4E 0.14.0 compatibility release

This incorporates the dependency-update intent of #55, while defining and testing the bounds jointly with FreeGSNKE rather than updating FreeGS4E in isolation.

## Coordination and merge order

This PR must be merged and FreeGS4E 0.14.0 released before the companion FreeGSNKE PR, FusionComputingLab/freegsnke#105. The FreeGSNKE branch requires `freegs4e>=0.14,<0.15` and tests directly against this branch until that release is available.

## Validation

Tested locally with no more than eight threads:

- Python 3.10.20 using the exact lower dependency bounds: 51 passed, 2 deselected
- Python 3.12.13 using the current resolver stack (including NumPy 2.4.6): 51 passed, 2 deselected
- Python 3.14.6 using the current resolver stack: 51 passed, 2 deselected
- coordinated FreeGSNKE suite on the same three stacks: 48 passed, 4 skipped in each environment
- source distribution and wheel builds completed successfully
- wheel-only FreeGS4E 0.14.0 + FreeGSNKE 3.1.0 installation imported successfully
- `pip check` reported no broken requirements on all three stacks
- the no-Numba fallback was exercised explicitly

The two deselected FreeGS4E tests fail identically on untouched `main`: `test_one_xpoint` and `test_readwrite`. They are called out explicitly in the workflow and are not regressions from this PR.
