### PR TITLE
Clarify FreeGS4E support scope and validate against FreeGSNKE

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - main
+    types: [opened, synchronize, reopened, labeled]
 
 jobs:
   tests:
@@ -23,3 +24,54 @@ jobs:
         run: python -m pip install ".[dev]"
       - name: Run test suite
         run: python -m pytest -v
+
+  downstream-freegsnke:
+    needs: tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - name: Checkout candidate FreeGS4E
+        uses: actions/checkout@v4
+        with:
+          path: freegs4e
+      - name: Checkout FreeGSNKE
+        uses: actions/checkout@v4
+        with:
+          repository: FusionComputingLab/freegsnke
+          path: freegsnke
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install candidate backend and FreeGSNKE
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e ./freegs4e
+          python -m pip install -e "./freegsnke[dev]"
+      - name: Run FreeGSNKE test suite
+        working-directory: freegsnke
+        run: python -m pytest -v
+      - name: Run self-contained FreeGSNKE examples
+        if: contains(github.event.pull_request.labels.*.name, 'ready-for-final-tests')
+        working-directory: freegsnke
+        run: |
+          notebooks=(
+            "examples/example00 - build_tokamak_machine.ipynb"
+            "examples/example01a - static_inverse_solve_MASTU.ipynb"
+            "examples/example01b - advanced_static_inverse_solve.ipynb"
+            "examples/example02 - static_forward_solve_MASTU.ipynb"
+            "examples/example03 - extracting_equilibrium_quantities.ipynb"
+            "examples/example04 - using_magnetic_probes.ipynb"
+            "examples/example05a - nonlinear_and_linear_evolution_with_GS.ipynb"
+            "examples/example05b - linear_evolution_without_GS.ipynb"
+            "examples/example05c - linear_evolution_with_relinearisation.ipynb"
+            "examples/example07a - Anamak.ipynb"
+            "examples/example07b - SPARC.ipynb"
+            "examples/example07c - ITER.ipynb"
+            "examples/example09 - virtual_circuits_MASTU.ipynb"
+            "examples/example10 - growth_rates.ipynb"
+            "examples/example11 - pulse_design_tool.ipynb"
+          )
+          for notebook in "${notebooks[@]}"; do
+            jupyter nbconvert --execute --to notebook --inplace "$notebook"
+          done

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,10 +21,5 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install package and test dependencies
         run: python -m pip install ".[dev]"
-      - name: Run compatibility suite
-        # These two tests also fail on main and are tracked separately from this
-        # dependency-compatibility change. Keep the remainder enforced here.
-        run: >-
-          python -m pytest -v
-          --deselect=freegs4e/test_critical.py::test_one_xpoint
-          --deselect=freegs4e/test_readwrite.py::test_readwrite
+      - name: Run test suite
+        run: python -m pytest -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -52,7 +52,12 @@ jobs:
         working-directory: freegsnke
         run: python -m pytest -v
       - name: Run self-contained FreeGSNKE examples
-        if: contains(github.event.pull_request.labels.*.name, 'ready-for-final-tests')
+        # Ignore unrelated label additions, but rerun after later commits or reopen events.
+        if: >-
+          (github.event.action == 'labeled' &&
+           github.event.label.name == 'ready-for-final-tests') ||
+          (github.event.action != 'labeled' &&
+           contains(github.event.pull_request.labels.*.name, 'ready-for-final-tests'))
         working-directory: freegsnke
         run: |
           notebooks=(

--- a/README.md
+++ b/README.md
@@ -12,8 +12,10 @@ Therefore, FreeGS4E is **not intended to be a drop in replacement solver for Fre
 The presence of an inherited module does not by itself mean that its original
 FreeGS workflow is supported. In particular, the standalone Picard inverse
 solver and its original control-constraint interface are not supported entry
-points for FreeGSNKE. See [Support scope](SUPPORT.md) for the backend API used by
-FreeGSNKE, known unsupported behaviour, and the status of retained legacy code.
+points for FreeGSNKE. See the
+[support scope](https://github.com/FusionComputingLab/freegs4e/blob/main/SUPPORT.md)
+for the backend API used by FreeGSNKE, known unsupported behaviour, and the
+status of retained legacy code.
 
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,18 +1,24 @@
 
 # FreeGS4E: Free-boundary Grad-Shafranov for Evolution
 
-FreeGS4E is a package forked from [FreeGS](https://github.com/freegs-plasma/freegs) (v0.6.1), which has the capability to solve the static inverse free-boundary Grad-Shafranov problem for plasma equilibria in tokamak devices.
+FreeGS4E is a package forked from [FreeGS](https://github.com/freegs-plasma/freegs) (v0.6.1). It retains substantial code inherited from that general-purpose equilibrium solver, but not all inherited workflows remain supported.
 
 Its intended usage is as an underlying solver for the dynamic (time-dependent) free-boundary equilibrium solver [FreeGSNKE](https://github.com/FusionComputingLab/freegsnke).
 
-The addtion and removal of certain features within FreeGS, as well as some performance optimisation, were neccesary to enable this and so FreeGS4E has now diverged significantly from original FreeGS codebase.
+The addition and removal of features, together with performance optimisations needed by FreeGSNKE, mean that FreeGS4E has diverged significantly from the original FreeGS codebase.
 
 Therefore, FreeGS4E is **not intended to be a drop in replacement solver for FreeGS** but rather is designed for use explicitly **within** [FreeGSNKE](https://github.com/FusionComputingLab/freegsnke).
+
+The presence of an inherited module does not by itself mean that its original
+FreeGS workflow is supported. In particular, the standalone Picard inverse
+solver and its original control-constraint interface are not supported entry
+points for FreeGSNKE. See [Support scope](SUPPORT.md) for the backend API used by
+FreeGSNKE, known unsupported behaviour, and the status of retained legacy code.
 
 
 ## Installation
 
-Given FreeGS4E is not a standalone equilibrium solver, we recommend following the [installation instructions for FreeGSNKE](https://docs.freegsnke.com/#installation) (which will install FreeGS4E automatically). 
+Because FreeGS4E is not a standalone equilibrium solver, we recommend following the [installation instructions for FreeGSNKE](https://docs.freegsnke.com/#installation) (which will install FreeGS4E automatically).
 
 If you would, however, like to contribute to FreeGS4E directly, please see the installation instructions in the section on contributing below.
 
@@ -25,7 +31,8 @@ tested in both repositories before release.
 
 ## Getting started
 
-All of the examples for getting started can be found within the `freegsnke/examples` directory.
+Supported examples can be found in the `freegsnke/examples` directory. Examples
+from the original FreeGS project should not be assumed to run with FreeGS4E.
 
 
 ## Contributing

--- a/SUPPORT.md
+++ b/SUPPORT.md
@@ -1,0 +1,72 @@
+# FreeGS4E support scope
+
+## Purpose
+
+FreeGS4E is the LGPL-licensed equilibrium backend used by FreeGSNKE. It is a
+separate distribution for licensing and release purposes, but its supported
+behaviour is defined primarily by the needs of FreeGSNKE.
+
+FreeGS4E was forked from FreeGS 0.6.1 and still contains inherited modules that
+are not part of the supported FreeGSNKE workflow. Their presence must not be
+interpreted as a claim that FreeGS4E is a drop-in replacement for FreeGS.
+
+## Backend functionality used by FreeGSNKE
+
+FreeGSNKE currently relies on the following FreeGS4E functionality, directly or
+through inheritance:
+
+- Grad-Shafranov operators and Green's functions in `gradshafranov`.
+- The direct elliptic solver exposed through `multigrid.createVcycle`.
+- Critical-point, separatrix, plasma-mask, and bilinear-interpolation helpers.
+- `Machine`, `Circuit`, `Wall`, `Coil`, and `MultiCoil` machine primitives.
+- The `Equilibrium` grid, field, and equilibrium-diagnostic implementation.
+- The profile bases `ConstrainBetapIp`, `ConstrainPaxisIp`, `Fiesta_Topeol`,
+  `Lao85`, `TensionSpline`, and `GeneralPprimeFFprime`.
+- Plotting helpers used by FreeGSNKE for equilibria, constraints, and probes.
+
+Changes to this functionality must be tested against both the FreeGS4E and
+FreeGSNKE test suites.
+
+## Known unsupported behaviour
+
+The following inherited FreeGS workflows are known not to satisfy their
+original tests on the current codebase:
+
+- The standalone `freegs4e.solve` Picard inverse workflow using
+  `freegs4e.control.constrain`. FreeGSNKE provides its own static and evolutive
+  solvers and does not use this route.
+- Calling the equilibrium-oriented `critical.find_critical` wrapper on a field
+  containing an X-point but no O-point. The lower-level `scan_for_crit` routine
+  can identify such an isolated X-point, but the wrapper requires an O-point to
+  order and filter X-points relative to the magnetic axis. FreeGSNKE plasma
+  equilibria require that magnetic axis.
+
+These behaviours are asserted explicitly in the test suite rather than hidden
+through CI deselection. This keeps the current contract visible and makes any
+change subject to review.
+
+## Retained but not validated for FreeGSNKE
+
+The following inherited functionality is not used by FreeGSNKE and is not part
+of its supported backend contract:
+
+- Standalone Picard and original FreeGS control interfaces.
+- Coil-position optimisation in `optimise` and `optimiser`.
+- Field-line tracing in `fieldtracer`.
+- HDF5 `OutputFile` persistence in `dump`.
+- A-EQDSK and DivGeo file utilities.
+- Hard-coded legacy machine constructors such as `DIIID`, `MAST`, `TCV`, and
+  the old built-in MAST-U descriptions.
+
+Some of this code has isolated inherited tests. Passing such a test demonstrates
+that specific behaviour only; it does not make the module a supported
+FreeGSNKE interface. G-EQDSK interoperability is treated separately because it
+is used alongside FreeGSNKE and has dedicated round-trip tests.
+
+## User guidance
+
+- Use FreeGSNKE APIs and examples for equilibrium solves.
+- Do not use the original FreeGS documentation as an API specification for
+  FreeGS4E.
+- Report backend issues in the FreeGSNKE issue tracker unless working directly
+  on the FreeGS4E backend.

--- a/freegs4e/README.md
+++ b/freegs4e/README.md
@@ -17,3 +17,38 @@ python -m pytest
 `multigrid.createVcycle` retains both direct and iterative implementations.
 The supported FreeGS4E and FreeGSNKE equilibrium paths currently use a
 single-level direct solve (`direct=True`).
+
+## Historical iterative multigrid demonstration
+
+> [!WARNING]
+> The iterative multigrid path is retained legacy functionality. It is not used
+> by the supported FreeGS4E or FreeGSNKE equilibrium workflows and is not
+> covered by representative correctness tests. Its numerical behaviour is
+> therefore not warranted.
+
+`multigrid.py` contains a demonstration for a two-dimensional Poisson problem
+on a square domain with fixed-value boundary conditions. It uses second-order
+central differences and compares Jacobi smoothing on the full mesh with a
+hierarchy of successively coarser meshes. Run the current demonstration from
+the repository root with:
+
+```shell
+python -m freegs4e.multigrid
+```
+
+The original demonstration started both solves with a maximum residual of
+`1.0`. In its historical configuration, 100 Jacobi iterations on the full mesh
+reduced the residual only to approximately `0.87`, whereas two multigrid
+V-cycles reported:
+
+```text
+Cycle 0: 0.0338261789164
+Cycle 1: 0.0022779802307
+```
+
+This comparison was illustrative rather than a controlled performance
+benchmark: interpolation adds overhead, while most multigrid smoothing occurs
+on cheaper coarse meshes. The current script configuration and output have
+since changed, so the values above are retained as historical context and are
+not expected test results or evidence that the iterative implementation remains
+correct.

--- a/freegs4e/README.md
+++ b/freegs4e/README.md
@@ -1,45 +1,19 @@
-FreeGS4E library
-================
+# FreeGS4E package internals
 
-Tests and examples using components of the library
+This directory contains the LGPL-licensed equilibrium backend used by
+FreeGSNKE. The supported surface and the status of retained FreeGS modules are
+documented in the repository-level [support scope](../SUPPORT.md).
 
-Testing
--------
+## Testing
 
-To run the unit tests, install [pytest](https://docs.pytest.org/en/latest/) and then run:
+Run the complete backend suite from the repository root with:
 
-    $ pytest
+```shell
+python -m pytest
+```
 
-Multigrid solver
-----------------
+## Linear solver
 
-The code in multigrid.py solves elliptic equations in a square domain, with Dirichlet (fixed value)
-boundary conditions. The smoother is a simple Jacobi method, and 2nd order
-central differences is used to discretise the operator. 
-The test case can be run with:
-
-    $ python multigrid.py
-
-This runs two solves. Both start with an initial maximum residual of 1.0.
-The first simulation uses only the full size mesh (no multigrid). 
-After 100 iterations it has only reduced the maximum residual error to 0.87
-
-    0 0.998475284655
-    ...
-    49 0.929067444026
-    ...
-    99 0.867532420282
-
-The second test solves the same problem, but now using 5 levels of mesh resolution
-(including the original). At each level 10 iterations of the Jacobi smoother
-are performed (5 on the way down, 5 on the way up), and two V-cycles are performed.
-In total then the same number of terations are performed as in the first test. 
-The output is:
-
-    Cycle  0 :  0.0338261789164
-    Cycle  1 :  0.0022779802307
-
-So after a single V-cycle the residual is reduced to 0.034, and to 0.0023 after two cycles.
-This comparison based on iteration count is not really fair, because there is some overhead for the interpolations. 
-On the other hand, most of the jacobi iterations are on a course mesh which is quicker than
-an iteration on the full size mesh. 
+`multigrid.createVcycle` retains both direct and iterative implementations.
+The supported FreeGS4E and FreeGSNKE equilibrium paths currently use a
+single-level direct solve (`direct=True`).

--- a/freegs4e/__init__.py
+++ b/freegs4e/__init__.py
@@ -36,6 +36,9 @@ from importlib import metadata
 
 __version__ = metadata.version("freegs4e")
 
+# Retained for compatibility with inherited FreeGS imports. ``solve``,
+# ``control``, and ``OutputFile`` are not FreeGSNKE backend entry points; see
+# SUPPORT.md for the supported interface and current legacy status.
 from . import control, jtor, machine, plotting
 from .dump import OutputFile
 from .equilibrium import Equilibrium

--- a/freegs4e/control.py
+++ b/freegs4e/control.py
@@ -1,7 +1,10 @@
 """
-Plasma control system
+Legacy FreeGS plasma-control constraints.
 
-Use constraints to adjust coil currents
+These classes belong to the inherited standalone Picard inverse workflow. They
+are not used by FreeGSNKE, which supplies its own inverse-solver constraints.
+The module is currently retained for compatibility while the legacy API is
+reviewed.
 """
 
 import numpy as np
@@ -14,8 +17,10 @@ from . import critical
 
 class constrain(object):
     """
-    Adjust coil currents using constraints. To use this class,
-    first create an instance by specifying the constraints
+    Adjust coil currents using the inherited FreeGS constraint implementation.
+
+    This is not a supported FreeGSNKE inverse-solver interface. To use this
+    legacy class, first create an instance by specifying the constraints:
 
     >>> controlsystem = constrain(xpoints = [(1.0, 1.1), (1.0,-1.0)])
 

--- a/freegs4e/dump.py
+++ b/freegs4e/dump.py
@@ -1,7 +1,9 @@
 """
-Class for reading/writing freegs4e `Equilibrium` objects
+Legacy HDF5 persistence for FreeGS4E `Equilibrium` objects.
 
-Currently just HDF5 via h5py
+This inherited format is not used by FreeGSNKE and is not part of its supported
+backend API. The isolated HDF5 round trip remains tested while the legacy I/O
+surface is reviewed.
 
 License
 -------
@@ -61,7 +63,7 @@ class OutputFile(object):
 
     Given an Equilibrium object, eq, write to file like:
 
-    >>> with freegs.OutputFile("test_readwrite.h5", 'w') as f:
+    >>> with freegs4e.OutputFile("test_readwrite.h5", 'w') as f:
     ...     f.write_equilibrium(eq)
 
     Read back into an Equilibrium like so:

--- a/freegs4e/picard.py
+++ b/freegs4e/picard.py
@@ -1,5 +1,9 @@
 """
-Routines for solving the nonlinear part of the Grad-Shafranov equation
+Legacy routines for solving the nonlinear part of the Grad-Shafranov equation.
+
+This inherited standalone solver is not used or supported by FreeGSNKE. Use
+the static or evolutive solvers provided by FreeGSNKE instead. The module is
+currently retained for compatibility while the legacy API is reviewed.
 
 Copyright 2024 Nicola C. Amorisco, Adriano Agnello, George K. Holt, Ben Dudson.
 
@@ -36,7 +40,13 @@ def solve(
     convergenceInfo=False,
 ):
     """
-    Perform Picard iteration to find solution to the Grad-Shafranov equation
+    Perform the inherited standalone Picard iteration.
+
+    Notes
+    -----
+    This is not a supported FreeGSNKE backend entry point. In particular, the
+    original inverse workflow using ``freegs4e.control`` is known not to satisfy
+    its inherited regression setup.
 
     eq       - an Equilibrium object (equilibrium.py)
     profiles - A Profile object for toroidal current (jtor.py)

--- a/freegs4e/test_backend_contract.py
+++ b/freegs4e/test_backend_contract.py
@@ -1,0 +1,83 @@
+"""Lightweight checks for the backend surface consumed by FreeGSNKE."""
+
+from . import (
+    bilinear_interpolation,
+    critical,
+    gradshafranov,
+    multigrid,
+    plotting,
+)
+from .coil import Coil
+from .equilibrium import Equilibrium
+from .jtor import (
+    ConstrainBetapIp,
+    ConstrainPaxisIp,
+    Fiesta_Topeol,
+    GeneralPprimeFFprime,
+    Lao85,
+    TensionSpline,
+)
+from .machine import Circuit, Machine, Wall
+from .multi_coil import MultiCoil
+
+
+def test_freegsnke_backend_contract():
+    """Keep changes to the documented FreeGSNKE dependency surface visible."""
+    required_callables = (
+        bilinear_interpolation.biliint,
+        critical.find_critical,
+        critical.scan_for_crit,
+        gradshafranov.Greens,
+        gradshafranov.GreensBr,
+        gradshafranov.GreensBz,
+        gradshafranov.GreensdBrdz,
+        gradshafranov.GSsparse,
+        gradshafranov.GSsparse4thOrder,
+        multigrid.createVcycle,
+        plotting.plotConstraints,
+        plotting.plotIOConstraints,
+        plotting.plotProbes,
+    )
+    assert all(callable(item) for item in required_callables)
+    assert gradshafranov.mu0 > 0
+
+    required_types = (
+        Coil,
+        Circuit,
+        Machine,
+        MultiCoil,
+        Wall,
+        Equilibrium,
+        ConstrainBetapIp,
+        ConstrainPaxisIp,
+        Fiesta_Topeol,
+        GeneralPprimeFFprime,
+        Lao85,
+        TensionSpline,
+    )
+    assert all(isinstance(item, type) for item in required_types)
+
+    required_machine_methods = (
+        "calcPsiFromGreens",
+        "createPsiGreens",
+        "createPsiGreensVec",
+        "getCurrents",
+    )
+    assert all(
+        callable(getattr(Machine, name, None))
+        for name in required_machine_methods
+    )
+
+    required_equilibrium_methods = (
+        "_updatePlasmaPsi",
+        "Br",
+        "Bz",
+        "plasmaCurrent",
+        "psi",
+        "separatrix",
+        "strikepoints",
+    )
+    assert all(
+        callable(getattr(Equilibrium, name, None))
+        for name in required_equilibrium_methods
+    )

--- a/freegs4e/test_critical.py
+++ b/freegs4e/test_critical.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from . import critical
 
@@ -41,12 +42,17 @@ def test_one_xpoint():
     def psi_func(R, Z):
         return (R - r0) ** 2 - (Z - z0) ** 2
 
-    opoints, xpoints = critical.find_critical(r2d, z2d, psi_func(r2d, z2d))
-
-    assert len(xpoints) == 1
+    # Low-level scanning remains meaningful for vacuum fields without an axis.
+    opoints, xpoints = critical.scan_for_crit(r2d, z2d, psi_func(r2d, z2d))
     assert len(opoints) == 0
+    assert len(xpoints) == 1
     assert np.isclose(xpoints[0][0], r0, atol=1.0 / nx)
     assert np.isclose(xpoints[0][1], z0, atol=1.0 / ny)
+
+    # The equilibrium-oriented wrapper requires an O-point to order and filter
+    # candidate X-points relative to the magnetic axis.
+    with pytest.raises(ValueError, match="No opoints found"):
+        critical.find_critical(r2d, z2d, psi_func(r2d, z2d))
 
 
 def test_doublet():

--- a/freegs4e/test_readwrite.py
+++ b/freegs4e/test_readwrite.py
@@ -1,12 +1,13 @@
 import io
 
+import pytest
 from numpy import allclose
 
 import freegs4e
 
 
 def test_readwrite():
-    """Test reading/writing to a file round-trip"""
+    """Test HDF5 reading/writing independently of the legacy Picard solver."""
 
     for tokamak in [
         freegs4e.machine.TestTokamak(),
@@ -23,21 +24,6 @@ def test_readwrite():
             ny=17,
             boundary=freegs4e.boundary.freeBoundaryHagenow,
         )
-        profiles = freegs4e.jtor.ConstrainPaxisIp(1e4, 1e6, 2.0)
-
-        # Note here the X-point locations and isoflux locations are not the same.
-        # The result will be an unbalanced double null configuration, where the
-        # X-points are on different flux surfaces.
-        xpoints = [(1.1, -0.6), (1.1, 0.8)]
-        isoflux = [(1.1, -0.6, 1.1, 0.6)]
-        constrain = freegs4e.control.constrain(
-            xpoints=xpoints, isoflux=isoflux
-        )
-
-        freegs4e.solve(
-            eq, profiles, constrain, maxits=25, atol=1e-3, rtol=1e-1
-        )
-
         memory_file = io.BytesIO()
 
         with freegs4e.OutputFile(memory_file, "w") as f:
@@ -48,3 +34,27 @@ def test_readwrite():
 
         assert tokamak == read_eq.tokamak
         assert allclose(eq.psi(), read_eq.psi())
+
+
+def test_original_readwrite_solve_setup_is_unsupported():
+    """Record the unsupported standalone solve formerly hidden by CI."""
+    eq = freegs4e.Equilibrium(
+        tokamak=freegs4e.machine.TestTokamak(),
+        Rmin=0.1,
+        Rmax=2.0,
+        Zmin=-1.0,
+        Zmax=1.0,
+        nx=17,
+        ny=17,
+        boundary=freegs4e.boundary.freeBoundaryHagenow,
+    )
+    profiles = freegs4e.jtor.ConstrainPaxisIp(1e4, 1e6, 2.0)
+    constrain = freegs4e.control.constrain(
+        xpoints=[(1.1, -0.6), (1.1, 0.8)],
+        isoflux=[(1.1, -0.6, 1.1, 0.6)],
+    )
+
+    with pytest.raises(ValueError, match="No opoints found"):
+        freegs4e.solve(
+            eq, profiles, constrain, maxits=25, atol=1e-3, rtol=1e-1
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.14.0"
 authors = [
     {name = "The FreeGS4E and FreeGS developers"}
 ]
-description = "Free boundary tokamak plasma equilibrium Grad-Shafranov solver for time evolution"
+description = "Grad-Shafranov equilibrium backend for FreeGSNKE"
 readme = "README.md"
 requires-python = ">=3.10"
 classifiers = [


### PR DESCRIPTION
## Summary

FreeGS4E has diverged substantially from the original FreeGS codebase and now exists primarily as the LGPL-licensed equilibrium backend for FreeGSNKE. However, several inherited FreeGS modules and entry points remain present and can give users the impression that their original workflows are still supported.

This PR makes the current support boundary explicit without removing legacy code or changing the runtime API.

## Changes

- Add `SUPPORT.md` describing the backend used by FreeGSNKE, known unsupported workflows, retained legacy functionality, and user guidance.
- Update the README and package metadata to describe FreeGS4E as the FreeGSNKE backend.
- Replace the stale internal README describing an old iterative V-cycle demonstration.
- Mark the inherited Picard solver, control constraints, and HDF5 persistence clearly in their module documentation.
- Retain existing top-level compatibility exports; no public symbols are removed.
- Separate the working HDF5 round-trip test from the unsupported standalone Picard/control workflow.
- Make the magnetic-axis requirement explicit: `scan_for_crit()` still supports isolated X-point detection, while the equilibrium-oriented `find_critical()` requires an O-point.
- Remove silent CI test deselection.
- Add a lightweight structural test for the backend surface consumed by FreeGSNKE.
- Run the complete FreeGSNKE pytest suite against candidate FreeGS4E branches.
- Run self-contained FreeGSNKE notebooks when labelled `ready-for-final-tests`; UDA-dependent examples remain excluded.

## Motivation

The previous repository state mixed actively supported backend functionality, inherited code that still happens to work, unvalidated legacy functionality, and an unsupported standalone workflow hidden from CI. This was brittle for maintainers and potentially misleading for new users.

## Runtime Impact

There are no intended runtime behavior changes. No legacy modules or top-level compatibility exports are removed.

## Validation

- FreeGS4E: `55 passed`
- FreeGSNKE against this candidate backend: `64 passed, 4 skipped`

The self-contained notebook suite is configured as the `ready-for-final-tests` CI stage.
