### PR TITLE
Fix GeneralPPrimeFFPrime

### DIFF
--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -23,7 +23,7 @@ along with FreeGS4E.  If not, see <http://www.gnu.org/licenses/>.
 import numpy as np
 from numpy import clip, pi, reshape, sqrt, zeros
 from scipy.integrate import quad, romb
-from scipy.interpolate import UnivariateSpline
+from scipy.interpolate import InterpolatedUnivariateSpline
 from scipy.special import beta as spbeta
 from scipy.special import betainc as spbinc
 
@@ -1643,10 +1643,10 @@ class GeneralPprimeFFprime(Profile):
         self.f_func = None
 
         if self.ffprime_data is not None:
-            self.ffprime_func = UnivariateSpline(self.psi_n, self.ffprime_data)
+            self.ffprime_func = InterpolatedUnivariateSpline(self.psi_n, self.ffprime_data)
 
         if self.f_data is not None:
-            self.f_func = UnivariateSpline(self.psi_n, self.f_data)
+            self.f_func = InterpolatedUnivariateSpline(self.psi_n, self.f_data)
 
         # if ffprime_func still not provided, use f_func derivative, else throw error
         if self.ffprime_func is None and self.f_func is not None:

--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -1625,10 +1625,10 @@ class GeneralPprimeFFprime(Profile):
         self.p_func = None
 
         if self.pprime_data is not None:
-            self.pprime_func = UnivariateSpline(self.psi_n, self.pprime_data)
+            self.pprime_func = InterpolatedUnivariateSpline(self.psi_n, self.pprime_data)
 
         if self.p_data is not None:
-            self.p_func = UnivariateSpline(self.psi_n, self.p_data)
+            self.p_func = InterpolatedUnivariateSpline(self.psi_n, self.p_data)
 
         # if pprime_func still not provided, use p_func derivative, else throw error
         if self.pprime_func is None and self.p_func is not None:

--- a/freegs4e/jtor.py
+++ b/freegs4e/jtor.py
@@ -1625,7 +1625,9 @@ class GeneralPprimeFFprime(Profile):
         self.p_func = None
 
         if self.pprime_data is not None:
-            self.pprime_func = InterpolatedUnivariateSpline(self.psi_n, self.pprime_data)
+            self.pprime_func = InterpolatedUnivariateSpline(
+                self.psi_n, self.pprime_data
+            )
 
         if self.p_data is not None:
             self.p_func = InterpolatedUnivariateSpline(self.psi_n, self.p_data)
@@ -1643,7 +1645,9 @@ class GeneralPprimeFFprime(Profile):
         self.f_func = None
 
         if self.ffprime_data is not None:
-            self.ffprime_func = InterpolatedUnivariateSpline(self.psi_n, self.ffprime_data)
+            self.ffprime_func = InterpolatedUnivariateSpline(
+                self.psi_n, self.ffprime_data
+            )
 
         if self.f_data is not None:
             self.f_func = InterpolatedUnivariateSpline(self.psi_n, self.f_data)


### PR DESCRIPTION
When using the GeneralPPrimeFFprime profile function, the existing interpolation applies arbitrary smoothing:

UnivariateSpline when used with just 2 arguments assumes s is None which smoothes the spline (undesired).
"If s is None, s will be set as len(w) for a smoothing spline that uses all data points. If 0, spline will interpolate through all data points. This is equivalent to [InterpolatedUnivariateSpline](https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.InterpolatedUnivariateSpline.html#scipy.interpolate.InterpolatedUnivariateSpline). Default is None."

from https://docs.scipy.org/doc/scipy/reference/generated/scipy.interpolate.UnivariateSpline.html

In this fix, we just change UnivariateSpline to InterpolatedUnivariateSpline to avoid this.