### PR TITLE
BUG: correct poloidalBeta3 normalization

### DIFF
--- a/freegs4e/equilibrium.py
+++ b/freegs4e/equilibrium.py
@@ -1934,7 +1934,8 @@ class Equilibrium:
         """
         Calculates poloidal beta from the following definition:
 
-            betap = ( integral(p) dV / V) / (integral(Bpol) dl / L)**2,
+            betap = 2 * mu0 * ( integral(p) dV / V)
+                    / (integral(Bpol) dl / L)**2,
 
         where:
          - p = pressure field.
@@ -1987,9 +1988,12 @@ class Equilibrium:
         # integrate
         integral_Bpol_lcfs = trapezoid(Bp, l)
 
-        return (pressure_integral / self.plasmaVolume()) / (
-            integral_Bpol_lcfs / self.separatrix_length()
-        ) ** 2
+        return (
+            2.0
+            * mu0
+            * (pressure_integral / self.plasmaVolume())
+            / (integral_Bpol_lcfs / self.separatrix_length()) ** 2
+        )
 
     def poloidalBeta4(self):
         """

--- a/freegs4e/test_equilibrium.py
+++ b/freegs4e/test_equilibrium.py
@@ -1,6 +1,9 @@
+from types import SimpleNamespace
+
 import numpy as np
 
 from . import boundary, equilibrium, jtor, picard
+from .gradshafranov import mu0
 
 
 def test_inoutseparatrix():
@@ -49,6 +52,51 @@ def test_fixed_boundary_psi():
 
     assert eq.psi_bndry == 0.0
     assert eq.poloidalBeta() > 0.0
+
+
+def test_poloidal_beta3_has_dimensionless_normalisation():
+    """Definition 3 includes 2*mu0 when normalised by Bpol squared."""
+
+    eq = object.__new__(equilibrium.Equilibrium)
+    eq.R, eq.Z = np.meshgrid([1.0, 2.0], [-0.5, 0.5], indexing="ij")
+    eq.dR = 1.0
+    eq.dZ = 1.0
+    eq._profiles = SimpleNamespace(limiter_core_mask=np.ones_like(eq.R))
+
+    pressure = 3.0
+    boundary_field = 2.0
+    separatrix = np.array(
+        [[1.0, -0.5], [2.0, -0.5], [2.0, 0.5], [1.0, 0.5], [1.0, -0.5]]
+    )
+    volume = np.sum(2.0 * np.pi * eq.R * eq.dR * eq.dZ)
+
+    def constant_psi(R, Z):
+        return np.zeros_like(R)
+
+    def constant_pressure(psi):
+        return np.full_like(psi, pressure)
+
+    def constant_boundary_field(R, Z):
+        return np.full_like(R, boundary_field)
+
+    def plasma_volume():
+        return volume
+
+    def separatrix_curve():
+        return separatrix
+
+    def boundary_length():
+        return 4.0
+
+    eq.psiNRZ = constant_psi
+    eq.pressure = constant_pressure
+    eq.plasmaVolume = plasma_volume
+    eq.separatrix = separatrix_curve
+    eq.separatrix_length = boundary_length
+    eq.Bpol = constant_boundary_field
+
+    expected = 2.0 * mu0 * pressure / boundary_field**2
+    assert np.isclose(eq.poloidalBeta3(), expected)
 
 
 def test_setSolverVcycle():


### PR DESCRIPTION
## Summary

`Equilibrium.poloidalBeta3()` calculates poloidal beta using the volume-averaged pressure and the LCFS-averaged poloidal magnetic field:

$$
\beta_p = \frac{2\mu_0 \langle p\rangle}{\langle B_{\mathrm{pol}}\rangle_{\mathrm{LCFS}}^2}.
$$

The implementation omitted the factor $2\mu_0$, causing the method to return a dimensional quantity rather than poloidal beta.

This PR:

- adds the missing $2\mu_0$ normalization;
- corrects the equation in the method documentation;
- adds a regression test using constant pressure and boundary field.

## Independent check

The correction was identified while comparing FreeGS4E equilibria with the EFIT++ poloidal-beta output for MAST-U shot 53320. Across 39 equilibrium times, the corrected definition reproduced the EFIT++ BPOLAV-normalized values with an RMSE of 0.020 and a correlation of 0.9976.

## Compatibility

This changes values returned by `poloidalBeta3()` by a factor of $2\mu_0$. The only in-repository use found outside the method itself is its display in example 3.

## Tests

`pytest freegs4e/test_equilibrium.py -q`

Result: 4 passed.

The complete local suite also reached 52 passing tests. Two unrelated tests failed in existing critical-point detection paths before any poloidal-beta calculation was reached.